### PR TITLE
fix: _apply_lora double-merge into dit in parallel_cfg mode

### DIFF
--- a/anima_gen.py
+++ b/anima_gen.py
@@ -20,7 +20,7 @@ CURRENT_LORA = {"path": None, "mul": 1.0}
 def _apply_lora(accelerator, models, lora_path, multiplier):
     import networks.lora_anima
     net, sd = networks.lora_anima.create_network_from_weights(
-        multiplier=multiplier, 
+        multiplier=multiplier,
         file=lora_path,
         ae=models["vae"],
         text_encoders=[models["qwen3"]],
@@ -28,13 +28,24 @@ def _apply_lora(accelerator, models, lora_path, multiplier):
         for_inference=True
     )
     net.merge_to([models["qwen3"]], models["dit"], sd, models["dtype"], accelerator.device)
-    
-    # Sync with secondary model if using Parallel CFG
+    del net
+
+    # Sync secondary model for Parallel CFG.
     if models.get("dit_secondary") is not None:
         sec_device = next(models["dit_secondary"].parameters()).device
-        net.merge_to([], models["dit_secondary"], sd, models["dtype"], sec_device)
-        
-    del net, sd
+        net_sec, _ = networks.lora_anima.create_network_from_weights(
+            multiplier=multiplier,
+            file=lora_path,
+            ae=models["vae"],
+            text_encoders=[],
+            unet=models["dit_secondary"],
+            for_inference=True,
+            weights_sd=sd,
+        )
+        net_sec.merge_to([], models["dit_secondary"], sd, models["dtype"], sec_device)
+        del net_sec
+
+    del sd
     torch.cuda.empty_cache()
 
 def manage_lora(accelerator, models, target_path, target_mul):


### PR DESCRIPTION
## Summary

- `_apply_lora` was calling `net.merge_to([], dit_secondary, ...)` on the same `net` object that was already used to merge into `dit`
- `LoRANetwork.merge_to` completely ignores its `unet` argument — it writes through `self.unet_loras`, which are module references bound to whichever model was passed to `create_network_from_weights` at construction time
- Because `net` was constructed with `unet=models["dit"]`, the second call silently double-merged into `dit` instead of touching `dit_secondary`
- In parallel_cfg mode this corrupted `dit` on every LoRA apply/unmerge, and `dit_secondary` was never updated, causing broken images whenever LoRA hot-swap was used

## Fix

Create a separate `net_sec` network bound to `dit_secondary` at construction time, reusing the already-loaded weights dict (`weights_sd=sd`) to avoid a second disk read. The primary merge path is unchanged.

```python
# Before (broken): reuses net bound to dit — writes into dit again
net.merge_to([], models["dit_secondary"], sd, models["dtype"], sec_device)

# After (correct): separate network whose unet_loras are bound to dit_secondary
net_sec, _ = networks.lora_anima.create_network_from_weights(
    multiplier=multiplier, file=lora_path,
    ae=models["vae"], text_encoders=[],
    unet=models["dit_secondary"],
    for_inference=True, weights_sd=sd,
)
net_sec.merge_to([], models["dit_secondary"], sd, models["dtype"], sec_device)
```

## Affected modes

- **parallel_cfg (2-GPU)** — broken on any runtime LoRA merge/unmerge; fixed by this PR
- **Single GPU / sharding** — `dit_secondary` is `None`, secondary block was already skipped; unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoRA merging with secondary models to properly isolate and apply weights to each model independently, ensuring correct behavior across multi-model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->