### PR TITLE
add Keep Last N States UI control for training state checkpoints

### DIFF
--- a/training-ui/public/index.html
+++ b/training-ui/public/index.html
@@ -190,6 +190,12 @@
                                     <input type="number" id="cfg-save-every" value="1" min="1">
                                 </div>
                             </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label>Keep Last N States</label>
+                                    <input type="number" id="cfg-keep-last-n-states-epochs" value="1" min="0">
+                                </div>
+                            </div>
                         </div>
 
                         <!-- Steps -->
@@ -202,6 +208,12 @@
                                 <div class="form-group">
                                     <label>Save Every N Steps</label>
                                     <input type="number" id="cfg-save-every-steps" value="500" min="1">
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label>Keep Last N States</label>
+                                    <input type="number" id="cfg-keep-last-n-states-steps" value="1" min="0">
                                 </div>
                             </div>
                         </div>

--- a/training-ui/public/js/app.js
+++ b/training-ui/public/js/app.js
@@ -649,7 +649,7 @@ function gatherConfig() {
         ? safeInt($("cfg-save-every").value)
         : undefined,
       save_last_n_epochs_state: isEpochs
-        ? safeInt($("cfg-keep-last-n-states-epochs").value)
+        ? safeInt($("cfg-keep-last-n-states-epochs").value, 1)
         : undefined,
       sample_every_n_epochs:
         isEpochs && enableSampling
@@ -662,7 +662,7 @@ function gatherConfig() {
         ? safeInt($("cfg-save-every-steps").value)
         : undefined,
       save_last_n_steps_state: !isEpochs
-        ? safeInt($("cfg-keep-last-n-states-steps").value)
+        ? safeInt($("cfg-keep-last-n-states-steps").value, 1)
         : undefined,
       sample_every_n_steps:
         !isEpochs && enableSampling

--- a/training-ui/public/js/app.js
+++ b/training-ui/public/js/app.js
@@ -376,8 +376,10 @@ function populateConfig(config) {
   updateDurationUnit();
   $("cfg-max-epochs").value = t.max_train_epochs ?? 20;
   $("cfg-save-every").value = t.save_every_n_epochs ?? 1;
+  $("cfg-keep-last-n-states-epochs").value = t.save_last_n_epochs_state ?? 1;
   $("cfg-max-steps").value = t.max_train_steps ?? 1000;
   $("cfg-save-every-steps").value = t.save_every_n_steps ?? 500;
+  $("cfg-keep-last-n-states-steps").value = t.save_last_n_steps_state ?? 1;
   $("cfg-output-name").value = t.output_name || "my_anima_lora";
   $("cfg-save-format").value = t.save_model_as || "safetensors";
   $("cfg-save-precision").value = t.save_precision || "bf16";
@@ -646,6 +648,9 @@ function gatherConfig() {
       save_every_n_epochs: isEpochs
         ? safeInt($("cfg-save-every").value)
         : undefined,
+      save_last_n_epochs_state: isEpochs
+        ? safeInt($("cfg-keep-last-n-states-epochs").value)
+        : undefined,
       sample_every_n_epochs:
         isEpochs && enableSampling
           ? safeInt($("cfg-sample-every").value)
@@ -655,6 +660,9 @@ function gatherConfig() {
         : undefined,
       save_every_n_steps: !isEpochs
         ? safeInt($("cfg-save-every-steps").value)
+        : undefined,
+      save_last_n_steps_state: !isEpochs
+        ? safeInt($("cfg-keep-last-n-states-steps").value)
         : undefined,
       sample_every_n_steps:
         !isEpochs && enableSampling

--- a/training-ui/server.js
+++ b/training-ui/server.js
@@ -373,6 +373,12 @@ function buildTrainingConfig(jobName, jobPath) {
         logging_dir: loggingDir,
         save_state: true
     };
+    // save_last_n_steps_state is in steps, but the UI field means "N checkpoints".
+    // Convert: multiply by save_every_n_steps so Python keeps the last N checkpoints.
+    if (merged.training_arguments.save_last_n_steps_state && merged.training_arguments.save_every_n_steps) {
+        merged.training_arguments.save_last_n_steps_state =
+            merged.training_arguments.save_last_n_steps_state * merged.training_arguments.save_every_n_steps;
+    }
 
     // Move resume from network_args to training_args
     if (jobConfig.network_arguments?.resume) {

--- a/training-ui/server.js
+++ b/training-ui/server.js
@@ -377,7 +377,7 @@ function buildTrainingConfig(jobName, jobPath) {
     // Convert: multiply by save_every_n_steps so Python keeps the last N checkpoints.
     if (merged.training_arguments.save_last_n_steps_state && merged.training_arguments.save_every_n_steps) {
         merged.training_arguments.save_last_n_steps_state =
-            merged.training_arguments.save_last_n_steps_state * merged.training_arguments.save_every_n_steps;
+            merged.training_arguments.save_last_n_steps_state * merged.training_arguments.save_every_n_steps - 1;
     }
 
     // Move resume from network_args to training_args

--- a/training-ui/server.js
+++ b/training-ui/server.js
@@ -371,9 +371,7 @@ function buildTrainingConfig(jobName, jobPath) {
         ...trainingArgs,
         output_dir: outputDir,
         logging_dir: loggingDir,
-        save_state: true,
-        save_last_n_steps_state: 1,
-        save_last_n_epochs_state: 1
+        save_state: true
     };
 
     // Move resume from network_args to training_args


### PR DESCRIPTION
Add a "Keep Last N States" number input to both the epochs and steps schedule sections, directly below their
respective Save Every N field. Setting it to 0 keeps all states; any positive number keeps the last N checkpoints.

For epochs, the value maps directly to save_last_n_epochs_state. For steps, the server converts the value to steps
(N × save_every_n_steps − 1) so that "Keep Last N States = 2" keeps exactly 2 checkpoint states in both modes.
Removes the hardcoded save_last_n_epochs_state: 1 / save_last_n_steps_state: 1 that previously deleted all but the latest state unconditionally.

Note: I did use **Claude Code** because I really needed this for my training. I tested it in both epoch and step mode, and it looks "clean" enough for you to work with.
I really wish this to be a feature of Anima-Standalone-Trainer, so I decided to open this pull request.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Keep Last N States" controls for both epoch-based and step-based training schedules, enabling flexible management of training state retention.

* **UI & Layout**
  * Reorganized Multi-GPU Parallelism Mode selector and DeepSpeed configuration panel for improved layout and usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gazingstars123/Anima-Standalone-Trainer/pull/47)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->