### PR TITLE
fix: transformers v5 compatibility

### DIFF
--- a/library/hunyuan_image_text_encoder.py
+++ b/library/hunyuan_image_text_encoder.py
@@ -4,12 +4,12 @@ from typing import Tuple, Optional, Union
 import torch
 from transformers import (
     AutoTokenizer,
+    PreTrainedTokenizer,
     Qwen2_5_VLConfig,
     Qwen2_5_VLForConditionalGeneration,
-    Qwen2Tokenizer,
+    Qwen2TokenizerFast,
     T5ForConditionalGeneration,
     T5Config,
-    T5Tokenizer,
 )
 from transformers.models.t5.modeling_t5 import T5Stack
 from accelerate import init_empty_weights
@@ -145,7 +145,7 @@ MULTILINGUAL_10_LANG_IDX_JSON = """{"en-Montserrat-Regular": 0, "en-Poppins-Ital
 "kr-WenQuanYiMicroHei": 120, "kr-YeonSung-Regular": 121}"""
 
 
-def add_special_token(tokenizer: T5Tokenizer, text_encoder: T5Stack):
+def add_special_token(tokenizer: PreTrainedTokenizer, text_encoder: T5Stack):
     """
     Add special tokens for color and font to tokenizer and text encoder.
 
@@ -173,7 +173,7 @@ def load_byt5(
     device: Union[str, torch.device],
     disable_mmap: bool = False,
     state_dict: Optional[dict] = None,
-) -> Tuple[T5Stack, T5Tokenizer]:
+) -> Tuple[T5Stack, PreTrainedTokenizer]:
     BYT5_CONFIG_JSON = """
 {
     "_name_or_path": "/home/patrick/t5/byt5-small",
@@ -240,7 +240,7 @@ def load_qwen2_5_vl(
     device: Union[str, torch.device],
     disable_mmap: bool = False,
     state_dict: Optional[dict] = None,
-) -> tuple[Qwen2Tokenizer, Qwen2_5_VLForConditionalGeneration]:
+) -> tuple[Qwen2TokenizerFast, Qwen2_5_VLForConditionalGeneration]:
     QWEN2_5_VL_CONFIG_JSON = """
 {
   "architectures": [
@@ -496,7 +496,7 @@ def load_qwen2_5_vl(
 
     # Load tokenizer
     logger.info(f"Loading tokenizer from {QWEN_2_5_VL_IMAGE_ID}")
-    tokenizer = Qwen2Tokenizer.from_pretrained(QWEN_2_5_VL_IMAGE_ID)
+    tokenizer = Qwen2TokenizerFast.from_pretrained(QWEN_2_5_VL_IMAGE_ID)
     return tokenizer, qwen2_5_vl
 
 
@@ -505,13 +505,13 @@ PROMPT_TEMPLATE_ENCODE_START_IDX = 34
 
 
 def get_qwen_prompt_embeds(
-    tokenizer: Qwen2Tokenizer, vlm: Qwen2_5_VLForConditionalGeneration, prompt: Union[str, list[str]] = None
+    tokenizer: Qwen2TokenizerFast, vlm: Qwen2_5_VLForConditionalGeneration, prompt: Union[str, list[str]] = None
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     input_ids, mask = get_qwen_tokens(tokenizer, prompt)
     return get_qwen_prompt_embeds_from_tokens(vlm, input_ids, mask)
 
 
-def get_qwen_tokens(tokenizer: Qwen2Tokenizer, prompt: Union[str, list[str]] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+def get_qwen_tokens(tokenizer: Qwen2TokenizerFast, prompt: Union[str, list[str]] = None) -> Tuple[torch.Tensor, torch.Tensor]:
     tokenizer_max_length = TOKENIZER_MAX_LENGTH
 
     # HunyuanImage-2.1 does not use "<|im_start|>assistant\n" in the prompt template
@@ -586,7 +586,7 @@ BYT5_MAX_LENGTH = 128
 
 
 def get_glyph_prompt_embeds(
-    tokenizer: T5Tokenizer, text_encoder: T5Stack, prompt: Optional[str] = None
+    tokenizer: PreTrainedTokenizer, text_encoder: T5Stack, prompt: Optional[str] = None
 ) -> Tuple[list[bool], torch.Tensor, torch.Tensor]:
     byt5_tokens, byt5_text_mask = get_byt5_text_tokens(tokenizer, prompt)
     return get_byt5_prompt_embeds_from_tokens(text_encoder, byt5_tokens, byt5_text_mask)

--- a/library/hunyuan_image_text_encoder.py
+++ b/library/hunyuan_image_text_encoder.py
@@ -173,7 +173,7 @@ def load_byt5(
     device: Union[str, torch.device],
     disable_mmap: bool = False,
     state_dict: Optional[dict] = None,
-) -> Tuple[T5Stack, PreTrainedTokenizer]:
+) -> Tuple[PreTrainedTokenizer, T5Stack]:
     BYT5_CONFIG_JSON = """
 {
     "_name_or_path": "/home/patrick/t5/byt5-small",

--- a/library/lpw_stable_diffusion.py
+++ b/library/lpw_stable_diffusion.py
@@ -9,7 +9,7 @@ import numpy as np
 import PIL.Image
 import torch
 from packaging import version
-from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer, CLIPVisionModelWithProjection
+from transformers import CLIPImageProcessor as CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer, CLIPVisionModelWithProjection
 
 import diffusers
 from diffusers import SchedulerMixin, StableDiffusionPipeline

--- a/library/sdxl_lpw_stable_diffusion.py
+++ b/library/sdxl_lpw_stable_diffusion.py
@@ -10,7 +10,7 @@ import PIL.Image
 import torch
 from packaging import version
 from tqdm import tqdm
-from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
+from transformers import CLIPImageProcessor as CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
 
 from diffusers import SchedulerMixin, StableDiffusionPipeline
 from diffusers.models import AutoencoderKL

--- a/library/strategy_anima.py
+++ b/library/strategy_anima.py
@@ -55,7 +55,7 @@ class AnimaTokenizeStrategy(TokenizeStrategy):
         text = [text] if isinstance(text, str) else text
 
         # Tokenize with Qwen3
-        qwen3_encoding = self.qwen3_tokenizer.batch_encode_plus(
+        qwen3_encoding = self.qwen3_tokenizer(
             text,
             return_tensors="pt",
             truncation=True,
@@ -66,7 +66,7 @@ class AnimaTokenizeStrategy(TokenizeStrategy):
         qwen3_attn_mask = qwen3_encoding["attention_mask"]
 
         # Tokenize with T5 (for LLM Adapter target tokens)
-        t5_encoding = self.t5_tokenizer.batch_encode_plus(
+        t5_encoding = self.t5_tokenizer(
             text,
             return_tensors="pt",
             truncation=True,

--- a/library/strategy_hunyuan_image.py
+++ b/library/strategy_hunyuan_image.py
@@ -2,7 +2,7 @@ import os
 from typing import Any, List, Optional, Tuple, Union
 import torch
 import numpy as np
-from transformers import AutoTokenizer, Qwen2Tokenizer
+from transformers import AutoTokenizer, Qwen2TokenizerFast
 
 from library import hunyuan_image_text_encoder, hunyuan_image_vae, train_util
 from library.strategy_base import LatentsCachingStrategy, TextEncodingStrategy, TokenizeStrategy, TextEncoderOutputsCachingStrategy
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class HunyuanImageTokenizeStrategy(TokenizeStrategy):
     def __init__(self, tokenizer_cache_dir: Optional[str] = None) -> None:
         self.vlm_tokenizer = self._load_tokenizer(
-            Qwen2Tokenizer, hunyuan_image_text_encoder.QWEN_2_5_VL_IMAGE_ID, tokenizer_cache_dir=tokenizer_cache_dir
+            Qwen2TokenizerFast, hunyuan_image_text_encoder.QWEN_2_5_VL_IMAGE_ID, tokenizer_cache_dir=tokenizer_cache_dir
         )
         self.byt5_tokenizer = self._load_tokenizer(
             AutoTokenizer, hunyuan_image_text_encoder.BYT5_TOKENIZER_PATH, subfolder="", tokenizer_cache_dir=tokenizer_cache_dir


### PR DESCRIPTION
sd-scripts v0.10.5 and v0.10.4 have introduced many Anima-related feature improvements and bug fixes, including key support for LoHA, LoKr, and Anima ControlNet-LLLite. However, this repository has not yet been updated accordingly.

## Summary

Ports two upstream fixes from kohya-ss/sd-scripts v0.10.5 so the trainer works on `transformers>=5.0.0` while remaining compatible with 4.x.

Without these changes Anima-Standalone-Trainer fails on transformers v5:
- `ImportError: cannot import name 'CLIPFeatureExtractor' from 'transformers'` — `CLIPFeatureExtractor` was renamed to `CLIPImageProcessor` in 4.x and fully removed in 5.x.
- `AttributeError: 'Qwen2TokenizerFast' object has no attribute 'batch_encode_plus'` — the legacy method is removed in 5.x; the tokenizer should be called directly.
- The slow `Qwen2Tokenizer` / `T5Tokenizer` classes are deprecated; type references should use `Qwen2TokenizerFast` and `PreTrainedTokenizer`.

## Upstream commits ported

- kohya-ss/sd-scripts@fd95682 — update tokenizer references to use `PreTrainedTokenizer` and `Qwen2TokenizerFast`
- kohya-ss/sd-scripts@0be3095 — replace deprecated `CLIPFeatureExtractor` with `CLIPImageProcessor`

Both shipped in sd-scripts v0.10.5 (2026-05-08).

## Changes

| File | Change |
|---|---|
| `library/strategy_anima.py` | `qwen3_tokenizer.batch_encode_plus(...)` and `t5_tokenizer.batch_encode_plus(...)` → direct `__call__` |
| `library/strategy_hunyuan_image.py` | `Qwen2Tokenizer` → `Qwen2TokenizerFast` |
| `library/hunyuan_image_text_encoder.py` | `Qwen2Tokenizer` → `Qwen2TokenizerFast` (5×), `T5Tokenizer` → `PreTrainedTokenizer` (3 type hints + import). The JSON config string `"ByT5Tokenizer"` is intentionally left untouched. |
| `library/lpw_stable_diffusion.py` | `from transformers import CLIPImageProcessor as CLIPFeatureExtractor, ...` |
| `library/sdxl_lpw_stable_diffusion.py` | same as above |

## Compatibility

`requirements.txt` pin of `transformers==4.54.1` is unchanged — code works on both 4.x and 5.x. Users on 5.x should also bump `diffusers` to the latest version (matches upstream README guidance for sd-scripts v0.10.5).