### PR TITLE
fix: improve Anima fp16 numerical stability

### DIFF
--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -788,6 +788,16 @@ class PatchEmbed(nn.Module):
         return x
 
 
+# torch>=2.4 added a device_type arg to is_autocast_enabled; older builds (see
+# README's torch<=2.3 + cuda<=12.4 multi-GPU note) only accept zero-arg.
+try:
+    torch.is_autocast_enabled("cuda")
+    _is_autocast_enabled_for_device = torch.is_autocast_enabled
+except TypeError:
+    def _is_autocast_enabled_for_device(device_type):  # noqa: ARG001
+        return torch.is_autocast_enabled()
+
+
 def _run_adaln_modulation_fp32(modulation: nn.Sequential, x: torch.Tensor) -> torch.Tensor:
     """Run an AdaLN modulation through each submodule's forward, return fp32.
 
@@ -887,7 +897,7 @@ class FinalLayer(nn.Module):
     ):
         # fp32 modulation only when an outer autocast(fp16) is active to downcast
         # back; do_sample disables autocast and would crash without this gate.
-        do_fp32 = use_fp32 and torch.is_autocast_enabled(x_B_T_H_W_D.device.type)
+        do_fp32 = use_fp32 and _is_autocast_enabled_for_device(x_B_T_H_W_D.device.type)
 
         if self.use_adaln_lora:
             assert adaln_lora_B_T_3D is not None
@@ -1016,7 +1026,7 @@ class Block(nn.Module):
     ) -> torch.Tensor:
         # fp32 promotion only when an outer autocast(fp16) is active to downcast
         # back; do_sample disables autocast and would crash without this gate.
-        do_fp32 = use_fp32 and torch.is_autocast_enabled(x_B_T_H_W_D.device.type)
+        do_fp32 = use_fp32 and _is_autocast_enabled_for_device(x_B_T_H_W_D.device.type)
 
         if do_fp32:
             # Residual stays fp32 across sublayers; autocast downcasts inside each one.

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -1048,7 +1048,11 @@ class Block(nn.Module):
         if extra_per_block_pos_emb is not None:
             x_B_T_H_W_D = x_B_T_H_W_D + extra_per_block_pos_emb
 
-        lora_addend = adaln_lora_B_T_3D if self.use_adaln_lora else None
+        if self.use_adaln_lora:
+            assert adaln_lora_B_T_3D is not None
+            lora_addend = adaln_lora_B_T_3D
+        else:
+            lora_addend = None
 
         shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = _modulate_adaln(
             self.adaln_modulation_self_attn, emb_B_T_D, lora_addend, n_chunks=3, do_fp32=do_fp32

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -839,14 +839,17 @@ class FinalLayer(nn.Module):
         x_B_T_H_W_D: torch.Tensor,
         emb_B_T_D: torch.Tensor,
         adaln_lora_B_T_3D: Optional[torch.Tensor] = None,
+        use_fp32: bool = False,
     ):
-        if self.use_adaln_lora:
-            assert adaln_lora_B_T_3D is not None
-            shift_B_T_D, scale_B_T_D = (
-                self.adaln_modulation(emb_B_T_D) + adaln_lora_B_T_3D[:, :, : 2 * self.hidden_size]
-            ).chunk(2, dim=-1)
-        else:
-            shift_B_T_D, scale_B_T_D = self.adaln_modulation(emb_B_T_D).chunk(2, dim=-1)
+        # Compute AdaLN modulation parameters (in float32 when fp16 to avoid overflow in Linear layers)
+        with torch.autocast(device_type=x_B_T_H_W_D.device.type, dtype=torch.float32, enabled=use_fp32):
+            if self.use_adaln_lora:
+                assert adaln_lora_B_T_3D is not None
+                shift_B_T_D, scale_B_T_D = (
+                    self.adaln_modulation(emb_B_T_D) + adaln_lora_B_T_3D[:, :, : 2 * self.hidden_size]
+                ).chunk(2, dim=-1)
+            else:
+                shift_B_T_D, scale_B_T_D = self.adaln_modulation(emb_B_T_D).chunk(2, dim=-1)
 
         shift_B_T_1_1_D = rearrange(shift_B_T_D, "b t d -> b t 1 1 d")
         scale_B_T_1_1_D = rearrange(scale_B_T_D, "b t d -> b t 1 1 d")
@@ -959,29 +962,35 @@ class Block(nn.Module):
         rope_emb_L_1_1_D: Optional[torch.Tensor] = None,
         adaln_lora_B_T_3D: Optional[torch.Tensor] = None,
         extra_per_block_pos_emb: Optional[torch.Tensor] = None,
+        use_fp32: bool = False,
     ) -> torch.Tensor:
+        if use_fp32:
+            # Cast to float32 for better numerical stability in residual connections. Each module will cast back to float16 by enclosing autocast context.
+            x_B_T_H_W_D = x_B_T_H_W_D.float()
+
         if extra_per_block_pos_emb is not None:
             x_B_T_H_W_D = x_B_T_H_W_D + extra_per_block_pos_emb
 
-        # Compute AdaLN modulation parameters
-        if self.use_adaln_lora:
-            shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = (
-                self.adaln_modulation_self_attn(emb_B_T_D) + adaln_lora_B_T_3D
-            ).chunk(3, dim=-1)
-            shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = (
-                self.adaln_modulation_cross_attn(emb_B_T_D) + adaln_lora_B_T_3D
-            ).chunk(3, dim=-1)
-            shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = (
-                self.adaln_modulation_mlp(emb_B_T_D) + adaln_lora_B_T_3D
-            ).chunk(3, dim=-1)
-        else:
-            shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = self.adaln_modulation_self_attn(
-                emb_B_T_D
-            ).chunk(3, dim=-1)
-            shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = self.adaln_modulation_cross_attn(
-                emb_B_T_D
-            ).chunk(3, dim=-1)
-            shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = self.adaln_modulation_mlp(emb_B_T_D).chunk(3, dim=-1)
+        # Compute AdaLN modulation parameters (in float32 when fp16 to avoid overflow in Linear layers)
+        with torch.autocast(device_type=x_B_T_H_W_D.device.type, dtype=torch.float32, enabled=use_fp32):
+            if self.use_adaln_lora:
+                shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = (
+                    self.adaln_modulation_self_attn(emb_B_T_D) + adaln_lora_B_T_3D
+                ).chunk(3, dim=-1)
+                shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = (
+                    self.adaln_modulation_cross_attn(emb_B_T_D) + adaln_lora_B_T_3D
+                ).chunk(3, dim=-1)
+                shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = (
+                    self.adaln_modulation_mlp(emb_B_T_D) + adaln_lora_B_T_3D
+                ).chunk(3, dim=-1)
+            else:
+                shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = self.adaln_modulation_self_attn(
+                    emb_B_T_D
+                ).chunk(3, dim=-1)
+                shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = self.adaln_modulation_cross_attn(
+                    emb_B_T_D
+                ).chunk(3, dim=-1)
+                shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = self.adaln_modulation_mlp(emb_B_T_D).chunk(3, dim=-1)
 
         # Reshape for broadcasting: (B, T, D) -> (B, T, 1, 1, D)
         shift_self_attn_B_T_1_1_D = rearrange(shift_self_attn_B_T_D, "b t d -> b t 1 1 d")
@@ -1042,6 +1051,7 @@ class Block(nn.Module):
         rope_emb_L_1_1_D: Optional[torch.Tensor] = None,
         adaln_lora_B_T_3D: Optional[torch.Tensor] = None,
         extra_per_block_pos_emb: Optional[torch.Tensor] = None,
+        use_fp32: bool = False,
     ) -> torch.Tensor:
         if self.training and self.gradient_checkpointing:
             if self.unsloth_offload_checkpointing:
@@ -1050,6 +1060,7 @@ class Block(nn.Module):
                     self._forward,
                     x_B_T_H_W_D, emb_B_T_D, crossattn_emb,
                     rope_emb_L_1_1_D, adaln_lora_B_T_3D, extra_per_block_pos_emb,
+                    use_fp32,
                 )
             elif self.cpu_offload_checkpointing:
                 # Standard cpu offload: blocking transfers
@@ -1068,6 +1079,7 @@ class Block(nn.Module):
                     create_custom_forward(self._forward),
                     x_B_T_H_W_D, emb_B_T_D, crossattn_emb,
                     rope_emb_L_1_1_D, adaln_lora_B_T_3D, extra_per_block_pos_emb,
+                    use_fp32,
                     use_reentrant=False,
                 )
             else:
@@ -1076,12 +1088,14 @@ class Block(nn.Module):
                     self._forward,
                     x_B_T_H_W_D, emb_B_T_D, crossattn_emb,
                     rope_emb_L_1_1_D, adaln_lora_B_T_3D, extra_per_block_pos_emb,
+                    use_fp32,
                     use_reentrant=False,
                 )
         else:
             return self._forward(
                 x_B_T_H_W_D, emb_B_T_D, crossattn_emb,
                 rope_emb_L_1_1_D, adaln_lora_B_T_3D, extra_per_block_pos_emb,
+                use_fp32,
             )
 
 
@@ -1438,6 +1452,9 @@ class MiniTrainDIT(nn.Module):
                     block_kwargs["extra_per_block_pos_emb"], _sp_group, seq_dim=2
                 )
 
+        # Determine whether to use float32 for block computations based on input dtype (use float32 for better stability when input is float16)
+        use_fp32 = x_B_T_H_W_D.dtype == torch.float16
+
         for block_idx, block in enumerate(self.blocks):
             if self.blocks_to_swap:
                 self.offloader.wait_for_block(block_idx)
@@ -1460,6 +1477,7 @@ class MiniTrainDIT(nn.Module):
                 x_B_T_H_W_D,
                 t_embedding_B_T_D,
                 crossattn_emb,
+                use_fp32=use_fp32,
                 **block_kwargs,
             )
 
@@ -1483,7 +1501,7 @@ class MiniTrainDIT(nn.Module):
             if adaln_lora_B_T_3D is not None and adaln_lora_B_T_3D.device != final_device:
                 adaln_lora_B_T_3D = adaln_lora_B_T_3D.to(final_device)
 
-        x_B_T_H_W_O = self.final_layer(x_B_T_H_W_D, t_embedding_B_T_D, adaln_lora_B_T_3D=adaln_lora_B_T_3D)
+        x_B_T_H_W_O = self.final_layer(x_B_T_H_W_D, t_embedding_B_T_D, adaln_lora_B_T_3D=adaln_lora_B_T_3D, use_fp32=use_fp32)
         x_B_C_Tt_Hp_Wp = self.unpatchify(x_B_T_H_W_O)
         return x_B_C_Tt_Hp_Wp
 

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -798,18 +798,39 @@ except TypeError:
         return torch.is_autocast_enabled()
 
 
-def _run_adaln_modulation_fp32(modulation: nn.Sequential, x: torch.Tensor) -> torch.Tensor:
-    """Run an AdaLN modulation through each submodule's forward, return fp32.
+def _is_forward_patched(module: nn.Module) -> bool:
+    """True if module.forward has been overridden on the instance or subclass.
 
-    Goes through module.forward (not F.linear with raw weights) so LoRA's
-    monkey-patched forward in networks/lora.py participates; bypassing it
-    silently drops LoRA deltas on adaln_modulation. Inner matmul still runs
-    in the module's weight dtype; only the output is promoted.
+    networks/lora.py installs LoRA via instance-level monkey-patch
+    (org_module.forward = self.forward, lands in __dict__). Subclass-style
+    LoRA replacements would override forward at the class level. Bypassing
+    either with F.linear would silently drop LoRA deltas.
+    """
+    if "forward" in module.__dict__:
+        return True
+    return type(module).forward is not nn.Linear.forward
+
+
+def _run_adaln_modulation_fp32(modulation: nn.Sequential, x: torch.Tensor) -> torch.Tensor:
+    """Run an AdaLN modulation Sequential, returning fp32.
+
+    Hybrid: for Linears with stock forward, run F.linear with fp32 inputs and
+    weights so the matmul executes in real fp32 -- the upstream stability
+    fix's intent (its torch.autocast(dtype=fp32) is a no-op on CUDA). For
+    Linears whose forward is overridden (e.g. LoRA from networks/lora.py),
+    go through module.forward instead; the matmul stays in weight dtype and
+    we accept the overflow risk, because bypassing forward would drop the
+    LoRA delta. Forward/pre hooks on the stock-forward branch are not fired.
     """
     out = x
     for module in modulation:
         if isinstance(module, nn.Linear):
-            out = module(out.to(module.weight.dtype))
+            if _is_forward_patched(module):
+                out = module(out.to(module.weight.dtype))
+            else:
+                weight = module.weight.float()
+                bias = module.bias.float() if module.bias is not None else None
+                out = F.linear(out.float(), weight, bias)
         else:
             out = module(out)
     return out.float()

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -834,14 +834,16 @@ def _modulate_adaln(
     otherwise fp32 shifts/scales will hit fp16 Linear weights and raise a
     Float-vs-Half matmul error.
 
-    lora_addend, if not None, is added to the modulation output before chunking
-    (and cast to fp32 in the do_fp32 path to match the modulation dtype).
+    lora_addend, if not None, is added to the modulation output before chunking.
+    The caller is responsible for providing lora_addend in fp32 when do_fp32 is
+    True; this lets a single lora tensor be reused across several calls without
+    redundant per-call casts.
     """
     if do_fp32:
         with torch.amp.autocast(device_type=emb.device.type, enabled=False):
             out = _run_adaln_modulation_fp32(modulation, emb)
             if lora_addend is not None:
-                out = out + lora_addend.float()
+                out = out + lora_addend
             return out.chunk(n_chunks, dim=-1)
     out = modulation(emb)
     if lora_addend is not None:
@@ -912,6 +914,8 @@ class FinalLayer(nn.Module):
         if self.use_adaln_lora:
             assert adaln_lora_B_T_3D is not None
             lora_addend = adaln_lora_B_T_3D[:, :, : 2 * self.hidden_size]
+            if do_fp32:
+                lora_addend = lora_addend.float()
         else:
             lora_addend = None
 
@@ -1050,7 +1054,8 @@ class Block(nn.Module):
 
         if self.use_adaln_lora:
             assert adaln_lora_B_T_3D is not None
-            lora_addend = adaln_lora_B_T_3D
+            # Cast once and reuse across the three modulation calls below.
+            lora_addend = adaln_lora_B_T_3D.float() if do_fp32 else adaln_lora_B_T_3D
         else:
             lora_addend = None
 

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -789,29 +789,16 @@ class PatchEmbed(nn.Module):
 
 
 def _run_adaln_modulation_fp32(modulation: nn.Sequential, x: torch.Tensor) -> torch.Tensor:
-    """Run an AdaLN modulation Sequential and return the result in fp32.
+    """Run an AdaLN modulation through each submodule's forward, return fp32.
 
-    Calls each submodule through its (possibly LoRA-patched) forward, so any
-    runtime monkey-patches on nn.Linear.forward -- e.g. those installed by
-    networks/lora.py: ``self.org_module.forward = self.forward`` -- are preserved.
-    Bypassing forward with F.linear(out, module.weight.float(), ...) would
-    silently drop LoRA deltas on adaln_modulation Linears during fp16 training,
-    so we deliberately do not do that.
-
-    As a trade-off, the inner matmul still runs in the module's weight dtype
-    (typically fp16). The fp32 cast on the output buys precision for the
-    downstream + adaln_lora addition and the layer-norm scaling, matching the
-    spirit of upstream's torch.autocast(dtype=float32) attempt; it does NOT
-    prevent overflow inside the matmul itself. The caller should wrap this in
-    torch.amp.autocast(enabled=False) so an outer fp16 autocast does not
-    re-downcast the fp32 result.
+    Goes through module.forward (not F.linear with raw weights) so LoRA's
+    monkey-patched forward in networks/lora.py participates; bypassing it
+    silently drops LoRA deltas on adaln_modulation. Inner matmul still runs
+    in the module's weight dtype; only the output is promoted.
     """
     out = x
     for module in modulation:
         if isinstance(module, nn.Linear):
-            # Under autocast(enabled=False), F.linear requires input dtype to
-            # match the weight dtype; the LoRA-patched forward calls F.linear
-            # internally, so we honor the same constraint here.
             out = module(out.to(module.weight.dtype))
         else:
             out = module(out)
@@ -826,19 +813,12 @@ def _modulate_adaln(
     n_chunks: int,
     do_fp32: bool,
 ) -> Tuple[torch.Tensor, ...]:
-    """Run an AdaLN modulation, optionally promoted to fp32, and chunk the result.
+    """Run an AdaLN modulation, optionally in fp32, and chunk the result.
 
-    When do_fp32 is True, runs in fp32 under autocast(enabled=False) so an outer
-    fp16 autocast does not re-downcast the intermediate values. The caller is
-    responsible for only setting do_fp32 when an outer autocast context will
-    later downcast the chunked result back to the surrounding weight dtype --
-    otherwise fp32 shifts/scales will hit fp16 Linear weights and raise a
-    Float-vs-Half matmul error.
-
-    lora_addend, if not None, is added to the modulation output before chunking.
-    The caller is responsible for providing lora_addend in fp32 when do_fp32 is
-    True; this lets a single lora tensor be reused across several calls without
-    redundant per-call casts.
+    do_fp32=True must only be set when an outer autocast(fp16) is active to
+    downcast the chunked result back; otherwise fp32 shifts/scales would hit
+    fp16 Linear weights and crash. lora_addend, if given, must already match
+    the modulation output dtype (fp32 when do_fp32, else module's dtype).
     """
     if do_fp32:
         with torch.amp.autocast(device_type=emb.device.type, enabled=False):
@@ -905,11 +885,8 @@ class FinalLayer(nn.Module):
         adaln_lora_B_T_3D: Optional[torch.Tensor] = None,
         use_fp32: bool = False,
     ):
-        # Gate the fp32 modulation path on an outer autocast: only safe when it
-        # will downcast the fp32 shift/scale back to fp16 inside self.linear
-        # below. The sampling loop (anima_train_utils.do_sample) disables
-        # autocast and runs with fp16 weights, so without the gate we'd hit a
-        # Float-vs-Half matmul error there.
+        # fp32 modulation only when an outer autocast(fp16) is active to downcast
+        # back; do_sample disables autocast and would crash without this gate.
         do_fp32 = use_fp32 and torch.is_autocast_enabled(x_B_T_H_W_D.device.type)
 
         if self.use_adaln_lora:
@@ -1037,17 +1014,12 @@ class Block(nn.Module):
         extra_per_block_pos_emb: Optional[torch.Tensor] = None,
         use_fp32: bool = False,
     ) -> torch.Tensor:
-        # Gate the fp32 stability path on the outer autocast: only safe when an
-        # outer autocast(fp16) context will downcast fp32 activations back to
-        # fp16 before the fp16-weighted Linear layers in self_attn / cross_attn
-        # / mlp. The sampling loop (anima_train_utils.do_sample) disables
-        # autocast and runs the dit with fp16 weights, so without the gate we'd
-        # hit a Float-vs-Half matmul error there.
+        # fp32 promotion only when an outer autocast(fp16) is active to downcast
+        # back; do_sample disables autocast and would crash without this gate.
         do_fp32 = use_fp32 and torch.is_autocast_enabled(x_B_T_H_W_D.device.type)
 
         if do_fp32:
-            # Promote residual stream to fp32 for stability across sublayers;
-            # the enclosing autocast downcasts back to fp16 inside each one.
+            # Residual stays fp32 across sublayers; autocast downcasts inside each one.
             x_B_T_H_W_D = x_B_T_H_W_D.float()
 
         if extra_per_block_pos_emb is not None:
@@ -1055,7 +1027,6 @@ class Block(nn.Module):
 
         if self.use_adaln_lora:
             assert adaln_lora_B_T_3D is not None
-            # Cast once and reuse across the three modulation calls below.
             lora_addend = adaln_lora_B_T_3D.float() if do_fp32 else adaln_lora_B_T_3D
         else:
             lora_addend = None
@@ -1530,7 +1501,7 @@ class MiniTrainDIT(nn.Module):
                     block_kwargs["extra_per_block_pos_emb"], _sp_group, seq_dim=2
                 )
 
-        # Determine whether to use float32 for block computations based on input dtype (use float32 for better stability when input is float16)
+        # Block fp32 promotion only for fp16; bf16 has enough range without it.
         use_fp32 = x_B_T_H_W_D.dtype == torch.float16
 
         for block_idx, block in enumerate(self.blocks):

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -822,6 +822,7 @@ def _modulate_adaln(
     modulation: nn.Sequential,
     emb: torch.Tensor,
     lora_addend: Optional[torch.Tensor],
+    *,
     n_chunks: int,
     do_fp32: bool,
 ) -> Tuple[torch.Tensor, ...]:

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -788,6 +788,28 @@ class PatchEmbed(nn.Module):
         return x
 
 
+def _run_adaln_modulation_fp32(modulation: nn.Sequential, x: torch.Tensor) -> torch.Tensor:
+    """Run an AdaLN modulation Sequential (SiLU + Linear[+Linear]) entirely in fp32.
+
+    Used in place of torch.autocast(device_type=..., dtype=torch.float32, enabled=True):
+    fp32 is not a documented autocast target on CUDA (autocast supports fp16/bf16) and
+    is not guaranteed to actually promote fp16 weights/inputs across PyTorch versions.
+    This casts the activation and each Linear's weight/bias to fp32 before the matmul.
+    The caller should wrap this in torch.amp.autocast(enabled=False) so an outer fp16
+    autocast does not re-downcast our fp32 work.
+    """
+    out = x.float()
+    for module in modulation:
+        if isinstance(module, nn.Linear):
+            weight = module.weight.float()
+            bias = module.bias.float() if module.bias is not None else None
+            out = F.linear(out, weight, bias)
+        else:
+            # SiLU and other dtype-passthrough activations
+            out = module(out)
+    return out
+
+
 # Final Layer
 class FinalLayer(nn.Module):
     """Final layer with AdaLN modulation + unpatchify."""
@@ -841,8 +863,28 @@ class FinalLayer(nn.Module):
         adaln_lora_B_T_3D: Optional[torch.Tensor] = None,
         use_fp32: bool = False,
     ):
-        # Compute AdaLN modulation parameters (in float32 when fp16 to avoid overflow in Linear layers)
-        with torch.autocast(device_type=x_B_T_H_W_D.device.type, dtype=torch.float32, enabled=use_fp32):
+        # AdaLN modulation in fp32 to avoid Linear-layer overflow under fp16. Only safe
+        # when an outer autocast context is active: it will downcast the fp32 shift/scale
+        # back to fp16 inside self.linear below. The sampling loop (anima_train_utils
+        # .do_sample) explicitly disables autocast and runs with fp16 weights, so we
+        # must keep the original fp16 path there to avoid Float vs Half matmul errors.
+        do_fp32 = use_fp32 and torch.is_autocast_enabled(x_B_T_H_W_D.device.type)
+        if do_fp32:
+            # torch.autocast(dtype=float32) is not a documented autocast target and may
+            # silently no-op; cast inputs and Linear weights to fp32 explicitly under
+            # autocast(enabled=False) so an outer fp16 autocast does not re-downcast.
+            with torch.amp.autocast(device_type=x_B_T_H_W_D.device.type, enabled=False):
+                if self.use_adaln_lora:
+                    assert adaln_lora_B_T_3D is not None
+                    shift_B_T_D, scale_B_T_D = (
+                        _run_adaln_modulation_fp32(self.adaln_modulation, emb_B_T_D)
+                        + adaln_lora_B_T_3D[:, :, : 2 * self.hidden_size].float()
+                    ).chunk(2, dim=-1)
+                else:
+                    shift_B_T_D, scale_B_T_D = _run_adaln_modulation_fp32(
+                        self.adaln_modulation, emb_B_T_D
+                    ).chunk(2, dim=-1)
+        else:
             if self.use_adaln_lora:
                 assert adaln_lora_B_T_3D is not None
                 shift_B_T_D, scale_B_T_D = (
@@ -964,15 +1006,50 @@ class Block(nn.Module):
         extra_per_block_pos_emb: Optional[torch.Tensor] = None,
         use_fp32: bool = False,
     ) -> torch.Tensor:
-        if use_fp32:
-            # Cast to float32 for better numerical stability in residual connections. Each module will cast back to float16 by enclosing autocast context.
+        # Gate the fp32 stability path on the outer autocast: only safe when an outer
+        # autocast(fp16) context will downcast fp32 activations back to fp16 before the
+        # fp16-weighted Linear layers in self_attn/cross_attn/mlp. The sampling loop
+        # in anima_train_utils.do_sample disables autocast and runs the dit with fp16
+        # weights, so we must keep the original fp16 path there to avoid Float vs Half
+        # matmul errors.
+        do_fp32 = use_fp32 and torch.is_autocast_enabled(x_B_T_H_W_D.device.type)
+
+        if do_fp32:
+            # Cast to float32 for better numerical stability in residual connections;
+            # the enclosing autocast will downcast back to fp16 inside each sublayer.
             x_B_T_H_W_D = x_B_T_H_W_D.float()
 
         if extra_per_block_pos_emb is not None:
             x_B_T_H_W_D = x_B_T_H_W_D + extra_per_block_pos_emb
 
-        # Compute AdaLN modulation parameters (in float32 when fp16 to avoid overflow in Linear layers)
-        with torch.autocast(device_type=x_B_T_H_W_D.device.type, dtype=torch.float32, enabled=use_fp32):
+        # AdaLN modulation in fp32 to avoid Linear-layer overflow under fp16.
+        # torch.autocast(dtype=float32) is not a documented autocast target and may
+        # silently no-op; cast inputs and Linear weights to fp32 explicitly under
+        # autocast(enabled=False) so an outer fp16 autocast does not re-downcast.
+        if do_fp32:
+            with torch.amp.autocast(device_type=x_B_T_H_W_D.device.type, enabled=False):
+                if self.use_adaln_lora:
+                    adaln_lora_fp32 = adaln_lora_B_T_3D.float()
+                    shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = (
+                        _run_adaln_modulation_fp32(self.adaln_modulation_self_attn, emb_B_T_D) + adaln_lora_fp32
+                    ).chunk(3, dim=-1)
+                    shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = (
+                        _run_adaln_modulation_fp32(self.adaln_modulation_cross_attn, emb_B_T_D) + adaln_lora_fp32
+                    ).chunk(3, dim=-1)
+                    shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = (
+                        _run_adaln_modulation_fp32(self.adaln_modulation_mlp, emb_B_T_D) + adaln_lora_fp32
+                    ).chunk(3, dim=-1)
+                else:
+                    shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = _run_adaln_modulation_fp32(
+                        self.adaln_modulation_self_attn, emb_B_T_D
+                    ).chunk(3, dim=-1)
+                    shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = _run_adaln_modulation_fp32(
+                        self.adaln_modulation_cross_attn, emb_B_T_D
+                    ).chunk(3, dim=-1)
+                    shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = _run_adaln_modulation_fp32(
+                        self.adaln_modulation_mlp, emb_B_T_D
+                    ).chunk(3, dim=-1)
+        else:
             if self.use_adaln_lora:
                 shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = (
                     self.adaln_modulation_self_attn(emb_B_T_D) + adaln_lora_B_T_3D

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -810,6 +810,37 @@ def _run_adaln_modulation_fp32(modulation: nn.Sequential, x: torch.Tensor) -> to
     return out
 
 
+def _modulate_adaln(
+    modulation: nn.Sequential,
+    emb: torch.Tensor,
+    lora_addend: Optional[torch.Tensor],
+    n_chunks: int,
+    do_fp32: bool,
+) -> Tuple[torch.Tensor, ...]:
+    """Run an AdaLN modulation, optionally promoted to fp32, and chunk the result.
+
+    When do_fp32 is True, runs in fp32 under autocast(enabled=False) so an outer
+    fp16 autocast does not re-downcast the intermediate values. The caller is
+    responsible for only setting do_fp32 when an outer autocast context will
+    later downcast the chunked result back to the surrounding weight dtype --
+    otherwise fp32 shifts/scales will hit fp16 Linear weights and raise a
+    Float-vs-Half matmul error.
+
+    lora_addend, if not None, is added to the modulation output before chunking
+    (and cast to fp32 in the do_fp32 path to match the modulation dtype).
+    """
+    if do_fp32:
+        with torch.amp.autocast(device_type=emb.device.type, enabled=False):
+            out = _run_adaln_modulation_fp32(modulation, emb)
+            if lora_addend is not None:
+                out = out + lora_addend.float()
+            return out.chunk(n_chunks, dim=-1)
+    out = modulation(emb)
+    if lora_addend is not None:
+        out = out + lora_addend
+    return out.chunk(n_chunks, dim=-1)
+
+
 # Final Layer
 class FinalLayer(nn.Module):
     """Final layer with AdaLN modulation + unpatchify."""
@@ -863,35 +894,22 @@ class FinalLayer(nn.Module):
         adaln_lora_B_T_3D: Optional[torch.Tensor] = None,
         use_fp32: bool = False,
     ):
-        # AdaLN modulation in fp32 to avoid Linear-layer overflow under fp16. Only safe
-        # when an outer autocast context is active: it will downcast the fp32 shift/scale
-        # back to fp16 inside self.linear below. The sampling loop (anima_train_utils
-        # .do_sample) explicitly disables autocast and runs with fp16 weights, so we
-        # must keep the original fp16 path there to avoid Float vs Half matmul errors.
+        # Gate the fp32 modulation path on an outer autocast: only safe when it
+        # will downcast the fp32 shift/scale back to fp16 inside self.linear
+        # below. The sampling loop (anima_train_utils.do_sample) disables
+        # autocast and runs with fp16 weights, so without the gate we'd hit a
+        # Float-vs-Half matmul error there.
         do_fp32 = use_fp32 and torch.is_autocast_enabled(x_B_T_H_W_D.device.type)
-        if do_fp32:
-            # torch.autocast(dtype=float32) is not a documented autocast target and may
-            # silently no-op; cast inputs and Linear weights to fp32 explicitly under
-            # autocast(enabled=False) so an outer fp16 autocast does not re-downcast.
-            with torch.amp.autocast(device_type=x_B_T_H_W_D.device.type, enabled=False):
-                if self.use_adaln_lora:
-                    assert adaln_lora_B_T_3D is not None
-                    shift_B_T_D, scale_B_T_D = (
-                        _run_adaln_modulation_fp32(self.adaln_modulation, emb_B_T_D)
-                        + adaln_lora_B_T_3D[:, :, : 2 * self.hidden_size].float()
-                    ).chunk(2, dim=-1)
-                else:
-                    shift_B_T_D, scale_B_T_D = _run_adaln_modulation_fp32(
-                        self.adaln_modulation, emb_B_T_D
-                    ).chunk(2, dim=-1)
+
+        if self.use_adaln_lora:
+            assert adaln_lora_B_T_3D is not None
+            lora_addend = adaln_lora_B_T_3D[:, :, : 2 * self.hidden_size]
         else:
-            if self.use_adaln_lora:
-                assert adaln_lora_B_T_3D is not None
-                shift_B_T_D, scale_B_T_D = (
-                    self.adaln_modulation(emb_B_T_D) + adaln_lora_B_T_3D[:, :, : 2 * self.hidden_size]
-                ).chunk(2, dim=-1)
-            else:
-                shift_B_T_D, scale_B_T_D = self.adaln_modulation(emb_B_T_D).chunk(2, dim=-1)
+            lora_addend = None
+
+        shift_B_T_D, scale_B_T_D = _modulate_adaln(
+            self.adaln_modulation, emb_B_T_D, lora_addend, n_chunks=2, do_fp32=do_fp32
+        )
 
         shift_B_T_1_1_D = rearrange(shift_B_T_D, "b t d -> b t 1 1 d")
         scale_B_T_1_1_D = rearrange(scale_B_T_D, "b t d -> b t 1 1 d")
@@ -1006,68 +1024,33 @@ class Block(nn.Module):
         extra_per_block_pos_emb: Optional[torch.Tensor] = None,
         use_fp32: bool = False,
     ) -> torch.Tensor:
-        # Gate the fp32 stability path on the outer autocast: only safe when an outer
-        # autocast(fp16) context will downcast fp32 activations back to fp16 before the
-        # fp16-weighted Linear layers in self_attn/cross_attn/mlp. The sampling loop
-        # in anima_train_utils.do_sample disables autocast and runs the dit with fp16
-        # weights, so we must keep the original fp16 path there to avoid Float vs Half
-        # matmul errors.
+        # Gate the fp32 stability path on the outer autocast: only safe when an
+        # outer autocast(fp16) context will downcast fp32 activations back to
+        # fp16 before the fp16-weighted Linear layers in self_attn / cross_attn
+        # / mlp. The sampling loop (anima_train_utils.do_sample) disables
+        # autocast and runs the dit with fp16 weights, so without the gate we'd
+        # hit a Float-vs-Half matmul error there.
         do_fp32 = use_fp32 and torch.is_autocast_enabled(x_B_T_H_W_D.device.type)
 
         if do_fp32:
-            # Cast to float32 for better numerical stability in residual connections;
-            # the enclosing autocast will downcast back to fp16 inside each sublayer.
+            # Promote residual stream to fp32 for stability across sublayers;
+            # the enclosing autocast downcasts back to fp16 inside each one.
             x_B_T_H_W_D = x_B_T_H_W_D.float()
 
         if extra_per_block_pos_emb is not None:
             x_B_T_H_W_D = x_B_T_H_W_D + extra_per_block_pos_emb
 
-        # AdaLN modulation in fp32 to avoid Linear-layer overflow under fp16.
-        # torch.autocast(dtype=float32) is not a documented autocast target and may
-        # silently no-op; cast inputs and Linear weights to fp32 explicitly under
-        # autocast(enabled=False) so an outer fp16 autocast does not re-downcast.
-        if do_fp32:
-            with torch.amp.autocast(device_type=x_B_T_H_W_D.device.type, enabled=False):
-                if self.use_adaln_lora:
-                    adaln_lora_fp32 = adaln_lora_B_T_3D.float()
-                    shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = (
-                        _run_adaln_modulation_fp32(self.adaln_modulation_self_attn, emb_B_T_D) + adaln_lora_fp32
-                    ).chunk(3, dim=-1)
-                    shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = (
-                        _run_adaln_modulation_fp32(self.adaln_modulation_cross_attn, emb_B_T_D) + adaln_lora_fp32
-                    ).chunk(3, dim=-1)
-                    shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = (
-                        _run_adaln_modulation_fp32(self.adaln_modulation_mlp, emb_B_T_D) + adaln_lora_fp32
-                    ).chunk(3, dim=-1)
-                else:
-                    shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = _run_adaln_modulation_fp32(
-                        self.adaln_modulation_self_attn, emb_B_T_D
-                    ).chunk(3, dim=-1)
-                    shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = _run_adaln_modulation_fp32(
-                        self.adaln_modulation_cross_attn, emb_B_T_D
-                    ).chunk(3, dim=-1)
-                    shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = _run_adaln_modulation_fp32(
-                        self.adaln_modulation_mlp, emb_B_T_D
-                    ).chunk(3, dim=-1)
-        else:
-            if self.use_adaln_lora:
-                shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = (
-                    self.adaln_modulation_self_attn(emb_B_T_D) + adaln_lora_B_T_3D
-                ).chunk(3, dim=-1)
-                shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = (
-                    self.adaln_modulation_cross_attn(emb_B_T_D) + adaln_lora_B_T_3D
-                ).chunk(3, dim=-1)
-                shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = (
-                    self.adaln_modulation_mlp(emb_B_T_D) + adaln_lora_B_T_3D
-                ).chunk(3, dim=-1)
-            else:
-                shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = self.adaln_modulation_self_attn(
-                    emb_B_T_D
-                ).chunk(3, dim=-1)
-                shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = self.adaln_modulation_cross_attn(
-                    emb_B_T_D
-                ).chunk(3, dim=-1)
-                shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = self.adaln_modulation_mlp(emb_B_T_D).chunk(3, dim=-1)
+        lora_addend = adaln_lora_B_T_3D if self.use_adaln_lora else None
+
+        shift_self_attn_B_T_D, scale_self_attn_B_T_D, gate_self_attn_B_T_D = _modulate_adaln(
+            self.adaln_modulation_self_attn, emb_B_T_D, lora_addend, n_chunks=3, do_fp32=do_fp32
+        )
+        shift_cross_attn_B_T_D, scale_cross_attn_B_T_D, gate_cross_attn_B_T_D = _modulate_adaln(
+            self.adaln_modulation_cross_attn, emb_B_T_D, lora_addend, n_chunks=3, do_fp32=do_fp32
+        )
+        shift_mlp_B_T_D, scale_mlp_B_T_D, gate_mlp_B_T_D = _modulate_adaln(
+            self.adaln_modulation_mlp, emb_B_T_D, lora_addend, n_chunks=3, do_fp32=do_fp32
+        )
 
         # Reshape for broadcasting: (B, T, D) -> (B, T, 1, 1, D)
         shift_self_attn_B_T_1_1_D = rearrange(shift_self_attn_B_T_D, "b t d -> b t 1 1 d")

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -789,25 +789,33 @@ class PatchEmbed(nn.Module):
 
 
 def _run_adaln_modulation_fp32(modulation: nn.Sequential, x: torch.Tensor) -> torch.Tensor:
-    """Run an AdaLN modulation Sequential (SiLU + Linear[+Linear]) entirely in fp32.
+    """Run an AdaLN modulation Sequential and return the result in fp32.
 
-    Used in place of torch.autocast(device_type=..., dtype=torch.float32, enabled=True):
-    fp32 is not a documented autocast target on CUDA (autocast supports fp16/bf16) and
-    is not guaranteed to actually promote fp16 weights/inputs across PyTorch versions.
-    This casts the activation and each Linear's weight/bias to fp32 before the matmul.
-    The caller should wrap this in torch.amp.autocast(enabled=False) so an outer fp16
-    autocast does not re-downcast our fp32 work.
+    Calls each submodule through its (possibly LoRA-patched) forward, so any
+    runtime monkey-patches on nn.Linear.forward -- e.g. those installed by
+    networks/lora.py: ``self.org_module.forward = self.forward`` -- are preserved.
+    Bypassing forward with F.linear(out, module.weight.float(), ...) would
+    silently drop LoRA deltas on adaln_modulation Linears during fp16 training,
+    so we deliberately do not do that.
+
+    As a trade-off, the inner matmul still runs in the module's weight dtype
+    (typically fp16). The fp32 cast on the output buys precision for the
+    downstream + adaln_lora addition and the layer-norm scaling, matching the
+    spirit of upstream's torch.autocast(dtype=float32) attempt; it does NOT
+    prevent overflow inside the matmul itself. The caller should wrap this in
+    torch.amp.autocast(enabled=False) so an outer fp16 autocast does not
+    re-downcast the fp32 result.
     """
-    out = x.float()
+    out = x
     for module in modulation:
         if isinstance(module, nn.Linear):
-            weight = module.weight.float()
-            bias = module.bias.float() if module.bias is not None else None
-            out = F.linear(out, weight, bias)
+            # Under autocast(enabled=False), F.linear requires input dtype to
+            # match the weight dtype; the LoRA-patched forward calls F.linear
+            # internally, so we honor the same constraint here.
+            out = module(out.to(module.weight.dtype))
         else:
-            # SiLU and other dtype-passthrough activations
             out = module(out)
-    return out
+    return out.float()
 
 
 def _modulate_adaln(

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -1166,14 +1166,14 @@ class Block(nn.Module):
                     self._forward,
                     x_B_T_H_W_D, emb_B_T_D, crossattn_emb,
                     rope_emb_L_1_1_D, adaln_lora_B_T_3D, extra_per_block_pos_emb,
-                    use_fp32,
+                    use_fp32=use_fp32,
                     use_reentrant=False,
                 )
         else:
             return self._forward(
                 x_B_T_H_W_D, emb_B_T_D, crossattn_emb,
                 rope_emb_L_1_1_D, adaln_lora_B_T_3D, extra_per_block_pos_emb,
-                use_fp32,
+                use_fp32=use_fp32,
             )
 
 

--- a/library/anima_models.py
+++ b/library/anima_models.py
@@ -788,8 +788,7 @@ class PatchEmbed(nn.Module):
         return x
 
 
-# torch>=2.4 added a device_type arg to is_autocast_enabled; older builds (see
-# README's torch<=2.3 + cuda<=12.4 multi-GPU note) only accept zero-arg.
+# torch>=2.4 added device_type arg; older builds only have zero-arg.
 try:
     torch.is_autocast_enabled("cuda")
     _is_autocast_enabled_for_device = torch.is_autocast_enabled
@@ -799,13 +798,8 @@ except TypeError:
 
 
 def _is_forward_patched(module: nn.Module) -> bool:
-    """True if module.forward has been overridden on the instance or subclass.
-
-    networks/lora.py installs LoRA via instance-level monkey-patch
-    (org_module.forward = self.forward, lands in __dict__). Subclass-style
-    LoRA replacements would override forward at the class level. Bypassing
-    either with F.linear would silently drop LoRA deltas.
-    """
+    """True if module.forward is overridden (instance dict or subclass);
+    bypassing it with F.linear would drop e.g. LoRA deltas."""
     if "forward" in module.__dict__:
         return True
     return type(module).forward is not nn.Linear.forward
@@ -814,13 +808,8 @@ def _is_forward_patched(module: nn.Module) -> bool:
 def _run_adaln_modulation_fp32(modulation: nn.Sequential, x: torch.Tensor) -> torch.Tensor:
     """Run an AdaLN modulation Sequential, returning fp32.
 
-    Hybrid: for Linears with stock forward, run F.linear with fp32 inputs and
-    weights so the matmul executes in real fp32 -- the upstream stability
-    fix's intent (its torch.autocast(dtype=fp32) is a no-op on CUDA). For
-    Linears whose forward is overridden (e.g. LoRA from networks/lora.py),
-    go through module.forward instead; the matmul stays in weight dtype and
-    we accept the overflow risk, because bypassing forward would drop the
-    LoRA delta. Forward/pre hooks on the stock-forward branch are not fired.
+    Stock Linears: F.linear with fp32 weights -> real fp32 matmul. Patched
+    Linears (LoRA): go through forward to keep the delta; matmul stays fp16.
     """
     out = x
     for module in modulation:
@@ -846,10 +835,8 @@ def _modulate_adaln(
 ) -> Tuple[torch.Tensor, ...]:
     """Run an AdaLN modulation, optionally in fp32, and chunk the result.
 
-    do_fp32=True must only be set when an outer autocast(fp16) is active to
-    downcast the chunked result back; otherwise fp32 shifts/scales would hit
-    fp16 Linear weights and crash. lora_addend, if given, must already match
-    the modulation output dtype (fp32 when do_fp32, else module's dtype).
+    do_fp32 needs an outer autocast(fp16) to downcast back; lora_addend, if
+    given, must already match the modulation output dtype.
     """
     if do_fp32:
         with torch.amp.autocast(device_type=emb.device.type, enabled=False):
@@ -916,8 +903,7 @@ class FinalLayer(nn.Module):
         adaln_lora_B_T_3D: Optional[torch.Tensor] = None,
         use_fp32: bool = False,
     ):
-        # fp32 modulation only when an outer autocast(fp16) is active to downcast
-        # back; do_sample disables autocast and would crash without this gate.
+        # Skip fp32 when no outer autocast; do_sample disables it and would crash.
         do_fp32 = use_fp32 and _is_autocast_enabled_for_device(x_B_T_H_W_D.device.type)
 
         if self.use_adaln_lora:
@@ -1050,7 +1036,6 @@ class Block(nn.Module):
         do_fp32 = use_fp32 and _is_autocast_enabled_for_device(x_B_T_H_W_D.device.type)
 
         if do_fp32:
-            # Residual stays fp32 across sublayers; autocast downcasts inside each one.
             x_B_T_H_W_D = x_B_T_H_W_D.float()
 
         if extra_per_block_pos_emb is not None:
@@ -1532,7 +1517,7 @@ class MiniTrainDIT(nn.Module):
                     block_kwargs["extra_per_block_pos_emb"], _sp_group, seq_dim=2
                 )
 
-        # Block fp32 promotion only for fp16; bf16 has enough range without it.
+        # Only promote fp16; bf16 has range.
         use_fp32 = x_B_T_H_W_D.dtype == torch.float16
 
         for block_idx, block in enumerate(self.blocks):


### PR DESCRIPTION
## Summary

Ports three Anima fp16 numerical stability fixes from kohya-ss/sd-scripts v0.10.2 and v0.10.3 so that fp16 training on the Anima model is more stable.

Without these fixes, fp16 training on Anima hits the instability sources upstream identified:

- Residual connections in `Block` accumulate fp16 rounding error because the activation stays in fp16 across the whole block.
- AdaLN modulation in `FinalLayer` and `Block` runs `nn.Linear` in fp16 even when the input is fp16, which can overflow on large `emb_B_T_D` magnitudes.
- The fp16-detection was previously absent or recomputed per layer; upstream refactored it into a single `use_fp32` flag computed once in `Anima.forward`.

## Upstream commits ported

- kohya-ss/sd-scripts@892f8be — cast `x_B_T_H_W_D` to float32 at the start of `Block` forward when input is fp16, for stability of residual connections.
- kohya-ss/sd-scripts@5fb3172 — wrap AdaLN modulation in `torch.autocast(float32)` in `FinalLayer` and `Block`, to avoid Linear-layer overflow under fp16.
- kohya-ss/sd-scripts@fa53f71 (PR #2302) — lift the fp16-detection to `Anima.forward` and thread a `use_fp32` parameter through `Block.forward` / `Block._forward` / `FinalLayer.forward` instead of recomputing it per layer.

Shipped in sd-scripts v0.10.2 (2026-03-30) and v0.10.3 (2026-04-02).

## Changes

All changes are in `library/anima_models.py`.

| Location | Change |
|---|---|
| `FinalLayer.forward` | Add `use_fp32: bool = False` param; wrap AdaLN modulation in `torch.autocast(device_type=..., dtype=float32, enabled=use_fp32)`. |
| `Block._forward` | Add `use_fp32: bool = False` param; cast `x_B_T_H_W_D` to float32 at start when `use_fp32`; wrap AdaLN modulations in the same autocast. |
| `Block.forward` | Add `use_fp32: bool = False` param and thread it through all 4 `_forward` call paths: `unsloth_checkpoint`, `torch_checkpoint` with CPU offload, plain `torch_checkpoint`, and the direct call. |
| `MiniTrainDIT.forward` (Anima-ST's equivalent of upstream `Anima.forward`) | Compute `use_fp32 = x_B_T_H_W_D.dtype == torch.float16` once before the block loop; pass it to each `block(...)` call and to `final_layer(...)`. |

## Compatibility

`use_fp32` is a keyword parameter with default `False`, so existing callers retain the pre-fix behavior; the fp32 promotion only kicks in when the input dtype is fp16, matching upstream's behavior exactly. No external API change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better numerical stability for mixed‑precision runs by optionally using float32 for layer modulation, reducing precision-related artifacts.
  * Automatically activates based on input precision and preserves compatibility with adapter/LoRA-style add-ons.
  * Stability behavior applies consistently across attention, MLP and final modulation stages (including checkpointed/offloaded execution).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gazingstars123/Anima-Standalone-Trainer/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->