### PR TITLE
feat: add Keep Last N States UI control for training state checkpoints

### DIFF
--- a/training-ui/public/index.html
+++ b/training-ui/public/index.html
@@ -194,6 +194,12 @@
                                     <input type="number" id="cfg-save-last-n-epochs" value="0" min="0" title="0 = keep all">
                                 </div>
                             </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label>Keep Last N States</label>
+                                    <input type="number" id="cfg-keep-last-n-states-epochs" value="1" min="0" title="0 = keep all states">
+                                </div>
+                            </div>
                         </div>
 
                         <!-- Steps -->
@@ -210,6 +216,12 @@
                                 <div class="form-group">
                                     <label>Keep Last N Steps</label>
                                     <input type="number" id="cfg-save-last-n-steps" value="0" min="0" title="0 = keep all">
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label>Keep Last N States</label>
+                                    <input type="number" id="cfg-keep-last-n-states-steps" value="1" min="0" title="0 = keep all states">
                                 </div>
                             </div>
                         </div>

--- a/training-ui/public/js/app.js
+++ b/training-ui/public/js/app.js
@@ -377,9 +377,11 @@ function populateConfig(config) {
   $("cfg-max-epochs").value = t.max_train_epochs ?? 20;
   $("cfg-save-every").value = t.save_every_n_epochs ?? 1;
   $("cfg-save-last-n-epochs").value = t.save_last_n_epochs ?? 0;
+  $("cfg-keep-last-n-states-epochs").value = t.save_last_n_epochs_state ?? 1;
   $("cfg-max-steps").value = t.max_train_steps ?? 1000;
   $("cfg-save-every-steps").value = t.save_every_n_steps ?? 500;
   $("cfg-save-last-n-steps").value = t.save_last_n_steps ?? 0;
+  $("cfg-keep-last-n-states-steps").value = t.save_last_n_steps_state ?? 1;
   $("cfg-output-name").value = t.output_name || "my_anima_lora";
   $("cfg-save-format").value = t.save_model_as || "safetensors";
   $("cfg-save-precision").value = t.save_precision || "bf16";
@@ -679,6 +681,9 @@ function gatherConfig() {
       save_last_n_epochs: isEpochs
         ? (safeInt($("cfg-save-last-n-epochs").value) || undefined)
         : undefined,
+      save_last_n_epochs_state: isEpochs
+        ? safeInt($("cfg-keep-last-n-states-epochs").value, 1)
+        : undefined,
       sample_every_n_epochs:
         isEpochs && enableSampling
           ? safeInt($("cfg-sample-every").value)
@@ -691,6 +696,9 @@ function gatherConfig() {
         : undefined,
       save_last_n_steps: !isEpochs
         ? (safeInt($("cfg-save-last-n-steps").value) || undefined)
+        : undefined,
+      save_last_n_steps_state: !isEpochs
+        ? safeInt($("cfg-keep-last-n-states-steps").value, 1)
         : undefined,
       sample_every_n_steps:
         !isEpochs && enableSampling

--- a/training-ui/server.js
+++ b/training-ui/server.js
@@ -371,10 +371,15 @@ function buildTrainingConfig(jobName, jobPath) {
         ...trainingArgs,
         output_dir: outputDir,
         logging_dir: loggingDir,
-        save_state: true,
-        save_last_n_steps_state: 1,
-        save_last_n_epochs_state: 1
+        save_state: true
     };
+
+    // save_last_n_steps_state is in steps, but the UI field means "N checkpoints".
+    // Convert: multiply by save_every_n_steps so the trainer keeps the last N checkpoint states.
+    if (merged.training_arguments.save_last_n_steps_state && merged.training_arguments.save_every_n_steps) {
+        merged.training_arguments.save_last_n_steps_state =
+            merged.training_arguments.save_last_n_steps_state * merged.training_arguments.save_every_n_steps - 1;
+    }
 
     // Move resume from network_args to training_args
     if (jobConfig.network_arguments?.resume) {


### PR DESCRIPTION
Add a "Keep Last N States" number input to both the epochs and steps schedule sections, directly below their respective Keep Last N field. Setting it to 0 keeps all states; any positive number keeps the last N checkpoint states.

For epochs, the value maps directly to save_last_n_epochs_state. For steps, the server converts the value to steps (N × save_every_n_steps − 1) so that "Keep Last N States = 2" keeps exactly 2 checkpoint states in both modes.

Removes the hardcoded save_last_n_epochs_state: 1 / save_last_n_steps_state: 1 that previously deleted all but the latest state unconditionally.


---

Reopened the PR with the requested fixes applied.