### PR TITLE
Add job queueing

### DIFF
--- a/training-ui/public/css/style.css
+++ b/training-ui/public/css/style.css
@@ -1672,3 +1672,76 @@ input:disabled, select:disabled {
     filter: grayscale(0.8);
     transition: opacity 0.2s ease;
 }
+
+/* === Queue Panel === */
+.queue-container {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 12px;
+    margin-bottom: 12px;
+}
+
+.queue-badge {
+    background: var(--warning);
+    color: #000;
+    border-radius: 12px;
+    padding: 2px 8px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    min-width: 24px;
+    text-align: center;
+}
+
+.queue-panel {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin-top: 8px;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.queue-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.queue-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.85rem;
+}
+
+.queue-item:last-child {
+    border-bottom: none;
+}
+
+.queue-item-name {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-right: 8px;
+    color: var(--text-primary);
+}
+
+.btn-remove-queue {
+    background: transparent;
+    border: none;
+    color: var(--danger);
+    cursor: pointer;
+    opacity: 0.6;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 2px 6px;
+    border-radius: 4px;
+    transition: all 0.15s;
+}
+
+.btn-remove-queue:hover {
+    opacity: 1;
+    background: rgba(248, 81, 73, 0.1);
+}

--- a/training-ui/public/css/style.css
+++ b/training-ui/public/css/style.css
@@ -676,7 +676,7 @@ body {
 
 .btn-warning {
     background: var(--warning);
-    color: #000;
+    color: var(--bg-primary);
 }
 
 .btn-warning:hover {
@@ -1682,7 +1682,7 @@ input:disabled, select:disabled {
 
 .queue-badge {
     background: var(--warning);
-    color: #000;
+    color: var(--bg-primary);
     border-radius: 12px;
     padding: 2px 8px;
     font-size: 0.75rem;

--- a/training-ui/public/css/style.css
+++ b/training-ui/public/css/style.css
@@ -220,6 +220,11 @@ body {
     animation: pulse 1.5s infinite;
 }
 
+.job-item.queued .status-dot {
+    background: var(--warning);
+    animation: pulse 2s infinite;
+}
+
 @keyframes pulse {
 
     0%,
@@ -667,6 +672,15 @@ body {
     background: var(--bg-tertiary);
     color: var(--text-primary);
     border-color: var(--text-secondary);
+}
+
+.btn-warning {
+    background: var(--warning);
+    color: #000;
+}
+
+.btn-warning:hover {
+    filter: brightness(1.1);
 }
 
 .btn-sm {

--- a/training-ui/public/index.html
+++ b/training-ui/public/index.html
@@ -49,6 +49,16 @@
                 <!-- Jobs rendered here -->
             </div>
             <div class="sidebar-footer">
+                <div id="queue-container" class="queue-container">
+                    <button id="btn-toggle-queue" class="btn btn-ghost btn-block" style="display: flex; justify-content: space-between; align-items: center;">
+                        <span style="display: flex; align-items: center; gap: 8px;">⏳ Queue</span>
+                        <span id="queue-badge" class="queue-badge hidden">0</span>
+                    </button>
+                    <div id="queue-panel" class="queue-panel hidden">
+                        <ul id="queue-list" class="queue-list">
+                            </ul>
+                    </div>
+                </div>
                 <button id="btn-global-settings" class="btn btn-ghost btn-block">⚙️ Global Settings</button>
             </div>
         </aside>

--- a/training-ui/public/index.html
+++ b/training-ui/public/index.html
@@ -50,11 +50,11 @@
             </div>
             <div class="sidebar-footer">
                 <div id="queue-container" class="queue-container">
-                    <button id="btn-toggle-queue" class="btn btn-ghost btn-block" style="display: flex; justify-content: space-between; align-items: center;">
+                    <button id="btn-toggle-queue" class="btn btn-ghost btn-block" aria-controls="queue-panel" aria-expanded="false" style="display: flex; justify-content: space-between; align-items: center;">
                         <span style="display: flex; align-items: center; gap: 8px;">⏳ Queue</span>
                         <span id="queue-badge" class="queue-badge hidden">0</span>
                     </button>
-                    <div id="queue-panel" class="queue-panel hidden">
+                    <div id="queue-panel" class="queue-panel hidden" role="region" aria-label="Training queue">
                         <ul id="queue-list" class="queue-list">
                             </ul>
                     </div>

--- a/training-ui/public/index.html
+++ b/training-ui/public/index.html
@@ -68,7 +68,7 @@
                         <button id="btn-save" class="btn btn-success hidden">💾 Save</button>
                         <button id="btn-discard" class="btn btn-danger hidden">Discard</button>
                         <button id="btn-clone" class="btn btn-secondary">Clone</button>
-                        <button id="btn-run" class="btn btn-primary">▶ Train</button>
+                        <button id="btn-run" class="btn btn-success">▶ Train</button>
                         <button id="btn-stop" class="btn btn-danger hidden">⏹ Stop</button>
                         <button id="btn-delete" class="btn btn-danger" title="Delete">🗑</button>
                     </div>

--- a/training-ui/public/js/app.js
+++ b/training-ui/public/js/app.js
@@ -2584,6 +2584,7 @@ async function loadQueueUI() {
 
 async function removeFromQueue(jobName) {
     showConfirm("Remove from Queue", `Remove "${jobName}" from the training queue?`, async () => {
+      try {
         await api(`/api/jobs/${jobName}/train/stop`, { method: "POST" });
         await loadQueueUI();
 
@@ -2595,12 +2596,17 @@ async function removeFromQueue(jobName) {
             updateJobStatus(jobName, "idle");
         }
         showToast("Job removed from queue");
+      } catch (err) {
++      showToast(`Failed to remove from queue: ${err.message}`);
+      }
     });
 }
 
 // Queue Toggle Binding
 $("btn-toggle-queue").addEventListener("click", () => {
-    $("queue-panel").classList.toggle("hidden");
+    const panel = $("queue-panel");
+    const isHidden = panel.classList.toggle("hidden");
+    $("btn-toggle-queue").setAttribute("aria-expanded", String(!isHidden));
 });
 
 // ==========================================
@@ -3289,9 +3295,13 @@ $("btn-stop").addEventListener("click", () => {
     title,
     message,
     async () => {
-      await api(`/api/jobs/${currentJob}/train/stop`, { method: "POST" });
-      updateJobStatus(currentJob, "idle");
-      showToast(isCancelQueue ? "Job removed from queue" : "Training stopped");
+      try {
+        await api(`/api/jobs/${currentJob}/train/stop`, { method: "POST" });
+        updateJobStatus(currentJob, "idle");
+        showToast(isCancelQueue ? "Job removed from queue" : "Training stopped");
+      } catch (err) {
+        showToast(`Failed to update training state: ${err.message}`);
+      }
     },
   );
 });

--- a/training-ui/public/js/app.js
+++ b/training-ui/public/js/app.js
@@ -84,7 +84,7 @@ function connectWS() {
         appendConsole(msg.data);
       } else if (msg.type === "status") {
         if (msg.data === "generating") return; // Ignore generation status for Training button
-        updateRunningState(msg.data === "running");
+        updateJobStatus(msg.data);
       }
     } catch (e) { }
   };
@@ -286,7 +286,15 @@ async function selectJob(name) {
     await loadPrompts();
     // Check run status
     const status = await api(`/api/jobs/${name}/train/status`);
-    updateRunningState(status.running);
+    const queue = await api("/api/train/queue");
+    const isQueued = queue.includes(name);
+    if (status.running) {
+    updateJobStatus("running");
+    } else if (isQueued) {
+        updateJobStatus("queued");
+    } else {
+        updateJobStatus("idle");
+    }
     // Set default negative prompt if no saved value exists for this job
     const savedTransient = localStorage.getItem(`prompt_transient_${name}`);
     if (!savedTransient || !JSON.parse(savedTransient).negative_prompt) {
@@ -319,14 +327,46 @@ async function selectJob(name) {
     emptyState.classList.remove("hidden");
   }
 }
-function updateRunningState(running) {
-  $("btn-run").classList.toggle("hidden", running);
-  $("btn-stop").classList.toggle("hidden", !running);
-  // Update sidebar dot
+
+// ==========================================
+// Form Locking
+// ==========================================
+// Form inputs deliberately remain unlocked and editable even when a job is 
+// queued or actively running. This lets the user adjust training arguments, 
+// dataset properties, or prompt arrays up until the precise second that 
+// the background worker pops the job from the queue and invokes the process.
+
+function updateJobStatus(status) {
+  const runBtn = $("btn-run");
+  const stopBtn = $("btn-stop");
+
+  if (status === "running") {
+    runBtn.classList.add("hidden");
+    stopBtn.classList.remove("hidden");
+    stopBtn.textContent = "⏹ Stop Training";
+    stopBtn.className = "btn btn-danger";
+  } else if (status === "queued") {
+    runBtn.classList.add("hidden");
+    stopBtn.classList.remove("hidden");
+    stopBtn.textContent = "⏹ Cancel Queue";
+    stopBtn.className = "btn btn-warning";
+  } else { // idle, dequeued, stopping, etc.
+    runBtn.classList.remove("hidden");
+    runBtn.textContent = "▶ Train";
+    runBtn.className = "btn btn-success";
+    stopBtn.classList.add("hidden");
+  }
+
+  // Sync sidebar indicators across all states
   document.querySelectorAll(".job-item").forEach((el) => {
     const name = el.querySelector(".job-name").textContent;
     if (name === currentJob) {
-      el.classList.toggle("running", running);
+      el.classList.remove("running", "queued");
+      if (status === "running") {
+        el.classList.add("running");
+      } else if (status === "queued") {
+        el.classList.add("queued");
+      }
     }
   });
 }
@@ -3093,7 +3133,7 @@ $("btn-run").addEventListener("click", async () => {
     alert(result.error);
     return;
   }
-  updateRunningState(true);
+  updateJobStatus("queued");
   consoleOutput.textContent = "";
   if (warningMsg) appendConsole(warningMsg);
   // Auto-switch to console tab
@@ -3157,13 +3197,18 @@ $("btn-refresh-checkpoints").addEventListener("click", () => {
 // Stop
 $("btn-stop").addEventListener("click", () => {
   if (!currentJob) return;
+  const stopBtnText = $("btn-stop").textContent;
+  const isCancelQueue = stopBtnText.includes("Cancel Queue");
+  const title = isCancelQueue ? "Cancel Queue" : "Stop Training";
+  const message = isCancelQueue ? `Remove "${currentJob}" from the training queue?` : `Stop training for "${currentJob}"?`;
+
   showConfirm(
-    "Stop Training",
-    `Stop training for "${currentJob}"?`,
+    title,
+    message,
     async () => {
       await api(`/api/jobs/${currentJob}/train/stop`, { method: "POST" });
-      updateRunningState(false);
-      showToast("Training stopped");
+      updateJobStatus("idle");
+      showToast(isCancelQueue ? "Job removed from queue" : "Training stopped");
     },
   );
 });

--- a/training-ui/public/js/app.js
+++ b/training-ui/public/js/app.js
@@ -79,12 +79,20 @@ function connectWS() {
         updateHwMonitor(msg.data);
         return;
       }
-      if (msg.job !== currentJob) return;
       if (msg.type === "log") {
-        appendConsole(msg.data);
+        // Only append console logs if we are actually looking at this job
+        if (msg.job === currentJob) {
+          appendConsole(msg.data);
+        }
       } else if (msg.type === "status") {
         if (msg.data === "generating") return; // Ignore generation status for Training button
-        updateJobStatus(msg.data);
+
+        // Refresh the queue UI if a relevant state changed
+        if (['queued', 'dequeued', 'running', 'idle'].includes(msg.data)) {
+            loadQueueUI();
+        }
+
+        updateJobStatus(msg.job, msg.data);
       }
     } catch (e) { }
   };
@@ -251,8 +259,13 @@ async function loadJobs() {
     return;
   }
   jobs.forEach((job) => {
+    // Determine the correct status class based on the new API payload
+    let statusClass = "";
+    if (job.running) statusClass = " running";
+    else if (job.queued) statusClass = " queued";
+
     const el = document.createElement("div");
-    el.className = `job-item${job.name === currentJob ? " active" : ""}${job.running ? " running" : ""}`;
+    el.className = `job-item${job.name === currentJob ? " active" : ""}${statusClass}`;
     el.innerHTML = `
             <div class="status-dot"></div>
             <span class="job-name">${job.name}</span>
@@ -289,11 +302,11 @@ async function selectJob(name) {
     const queue = await api("/api/train/queue");
     const isQueued = queue.includes(name);
     if (status.running) {
-    updateJobStatus("running");
+    updateJobStatus(name, "running");
     } else if (isQueued) {
-        updateJobStatus("queued");
+        updateJobStatus(name, "queued");
     } else {
-        updateJobStatus("idle");
+        updateJobStatus(name, "idle");
     }
     // Set default negative prompt if no saved value exists for this job
     const savedTransient = localStorage.getItem(`prompt_transient_${name}`);
@@ -336,31 +349,34 @@ async function selectJob(name) {
 // dataset properties, or prompt arrays up until the precise second that 
 // the background worker pops the job from the queue and invokes the process.
 
-function updateJobStatus(status) {
-  const runBtn = $("btn-run");
-  const stopBtn = $("btn-stop");
+function updateJobStatus(jobName, status) {
+  // Only update editor buttons if this is the active job
+  if (jobName === currentJob) {
+    const runBtn = $("btn-run");
+    const stopBtn = $("btn-stop");
 
-  if (status === "running") {
-    runBtn.classList.add("hidden");
-    stopBtn.classList.remove("hidden");
-    stopBtn.textContent = "⏹ Stop Training";
-    stopBtn.className = "btn btn-danger";
-  } else if (status === "queued") {
-    runBtn.classList.add("hidden");
-    stopBtn.classList.remove("hidden");
-    stopBtn.textContent = "⏹ Cancel Queue";
-    stopBtn.className = "btn btn-warning";
-  } else { // idle, dequeued, stopping, etc.
-    runBtn.classList.remove("hidden");
-    runBtn.textContent = "▶ Train";
-    runBtn.className = "btn btn-success";
-    stopBtn.classList.add("hidden");
+    if (status === "running") {
+      runBtn.classList.add("hidden");
+      stopBtn.classList.remove("hidden");
+      stopBtn.textContent = "⏹ Stop Training";
+      stopBtn.className = "btn btn-danger";
+    } else if (status === "queued") {
+      runBtn.classList.add("hidden");
+      stopBtn.classList.remove("hidden");
+      stopBtn.textContent = "⏹ Cancel Queue";
+      stopBtn.className = "btn btn-warning";
+    } else {
+      runBtn.classList.remove("hidden");
+      runBtn.textContent = "▶ Train";
+      runBtn.className = "btn btn-success";
+      stopBtn.classList.add("hidden");
+    }
   }
 
-  // Sync sidebar indicators across all states
+  // Always sync sidebar indicators regardless of what job is selected
   document.querySelectorAll(".job-item").forEach((el) => {
     const name = el.querySelector(".job-name").textContent;
-    if (name === currentJob) {
+    if (name === jobName) {
       el.classList.remove("running", "queued");
       if (status === "running") {
         el.classList.add("running");
@@ -2518,6 +2534,75 @@ $("cfg-text-shadow").oninput = (e) => {
 $("cfg-theme").onchange = (e) => {
   applyTheme(e.target.value);
 };
+
+// ==========================================
+//  Queue UI
+// ==========================================
+async function loadQueueUI() {
+    try {
+        const queue = await api("/api/train/queue");
+        const badge = $("queue-badge");
+        const list = $("queue-list");
+
+        // Update Badge
+        if (queue.length > 0) {
+            badge.textContent = queue.length;
+            badge.classList.remove("hidden");
+        } else {
+            badge.classList.add("hidden");
+        }
+
+        // Render List
+        list.innerHTML = "";
+        if (queue.length === 0) {
+            list.innerHTML = '<li style="padding: 12px; text-align: center; color: var(--text-muted); font-size: 0.8rem;">Queue is empty</li>';
+            return;
+        }
+
+        queue.forEach((job, index) => {
+            const li = document.createElement("li");
+            li.className = "queue-item";
+            li.innerHTML = `
+                <span class="queue-item-name" title="${escapeHtml(job)}">
+                    <span style="color:var(--text-muted); margin-right:4px;">${index + 1}.</span>
+                    ${escapeHtml(job)}
+                </span>
+                <button class="btn-remove-queue" title="Remove from queue">✕</button>
+            `;
+
+            // Remove Button Click
+            li.querySelector(".btn-remove-queue").addEventListener("click", (e) => {
+                e.stopPropagation();
+                removeFromQueue(job);
+            });
+            list.appendChild(li);
+        });
+    } catch (err) {
+        console.error("Failed to load queue:", err);
+    }
+}
+
+async function removeFromQueue(jobName) {
+    showConfirm("Remove from Queue", `Remove "${jobName}" from the training queue?`, async () => {
+        await api(`/api/jobs/${jobName}/train/stop`, { method: "POST" });
+        await loadQueueUI();
+
+        // If the user happens to have this job open in the editor, revert its buttons
+        if (currentJob === jobName) {
+            updateJobStatus(jobName, "idle");
+        } else {
+            // Update the sidebar dot for the background job
+            updateJobStatus(jobName, "idle");
+        }
+        showToast("Job removed from queue");
+    });
+}
+
+// Queue Toggle Binding
+$("btn-toggle-queue").addEventListener("click", () => {
+    $("queue-panel").classList.toggle("hidden");
+});
+
 // ==========================================
 //  Modals & Helpers
 // ==========================================
@@ -3133,12 +3218,10 @@ $("btn-run").addEventListener("click", async () => {
     alert(result.error);
     return;
   }
-  updateJobStatus("queued");
   consoleOutput.textContent = "";
   if (warningMsg) appendConsole(warningMsg);
-  // Auto-switch to console tab
   document.querySelector('[data-tab="console"]').click();
-  showToast("Training started");
+  showToast(result.status === 'queued' ? "Job added to queue" : "Training started");
 });
 // Generate
 $("btn-gen-sample").addEventListener("click", async () => {
@@ -3207,7 +3290,7 @@ $("btn-stop").addEventListener("click", () => {
     message,
     async () => {
       await api(`/api/jobs/${currentJob}/train/stop`, { method: "POST" });
-      updateJobStatus("idle");
+      updateJobStatus(currentJob, "idle");
       showToast(isCancelQueue ? "Job removed from queue" : "Training stopped");
     },
   );
@@ -3426,6 +3509,8 @@ async function init() {
   // 2. Normal Init
   connectWS();
   await loadJobs();
+  // Load queue
+  loadQueueUI();
   // Start status polling
   setInterval(updateGPUActivity, 3000);
   // Watch for config changes

--- a/training-ui/server.js
+++ b/training-ui/server.js
@@ -327,15 +327,13 @@ function broadcastLog(jobName, message) {
 }
 
 function broadcastStatus(jobName, status) {
-    const clients = wsClients.get(jobName);
-    if (clients) {
-        const data = JSON.stringify({ job: jobName, type: 'status', data: status });
-        clients.forEach(ws => {
-            if (ws.readyState === WebSocket.OPEN) {
-                ws.send(data);
-            }
-        });
-    }
+    // Send status to ALL connected clients so the sidebar and queue panel stay in sync
+    const data = JSON.stringify({ job: jobName, type: 'status', data: status });
+    wss.clients.forEach(ws => {
+        if (ws.readyState === WebSocket.OPEN) {
+            ws.send(data);
+        }
+    });
 }
 
 // Find the most recently modified state folder in a job's output directory
@@ -615,10 +613,13 @@ app.get('/api/jobs', (req, res) => {
                 if (hasConfig) {
                     try { mtime = fs.statSync(configPath).mtimeMs; } catch (e) { }
                 }
+                const jobData = runningJobs.get(d.name);
+                const isRunning = jobData ? jobData.type === 'training' : false;
                 return {
                     name: d.name,
                     hasConfig,
-                    running: runningJobs.has(d.name),
+                    running: isRunning,
+                    queued: trainingQueue.includes(d.name),
                     mtime
                 };
             })
@@ -1510,7 +1511,8 @@ app.post('/api/jobs/:name/train/start', async (req, res) => {
         broadcastStatus(jobName, 'queued');
         processTrainingQueue();
 
-        res.json({ success: true, status: 'queued' });
+        const isRunning = runningJobs.has(jobName);
+        res.json({ success: true, status: isRunning ? 'running' : 'queued' });
     } catch (err) {
         res.status(500).json({ error: err.message });
     }

--- a/training-ui/server.js
+++ b/training-ui/server.js
@@ -497,10 +497,11 @@ wss.on('connection', (ws) => {
 
                 // Send current status
                 const isRunning = runningJobs.has(msg.job);
+                const isQueued = trainingQueue.includes(msg.job);
                 ws.send(JSON.stringify({
                     job: msg.job,
                     type: 'status',
-                    data: isRunning ? 'running' : 'idle'
+                    data: isRunning ? 'running' : (isQueued ? 'queued' : 'idle')
                 }));
 
                 // Send buffered logs

--- a/training-ui/server.js
+++ b/training-ui/server.js
@@ -85,6 +85,10 @@ if (!fs.existsSync(GLOBAL_CONFIG_PATH) && fs.existsSync(TEMPLATE_CONFIG_PATH)) {
 // Track running processes
 const runningJobs = new Map();
 
+// Training jobs queue
+const QUEUE_FILE_PATH = path.join(__dirname, 'queue.json');
+const trainingQueue = loadQueue();
+
 // WebSocket clients per job
 const wsClients = new Map(); // jobName -> Set<ws>
 
@@ -127,6 +131,26 @@ function getGlobalConfig() {
         },
         venv_path: path.join(ROOT_DIR, 'venv')
     };
+}
+
+function saveQueue() {
+    try {
+        fs.writeFileSync(QUEUE_FILE_PATH, JSON.stringify(trainingQueue, null, 2), 'utf8');
+    } catch (err) {
+        console.error("Failed to persist training queue to disk:", err);
+    }
+}
+
+function loadQueue() {
+    if (fs.existsSync(QUEUE_FILE_PATH)) {
+        try {
+            const data = fs.readFileSync(QUEUE_FILE_PATH, 'utf8');
+            return JSON.parse(data);
+        } catch (err) {
+            console.error("Failed to parse persisted training queue, starting fresh:", err);
+        }
+    }
+    return []; // Fallback if file doesn't exist or is corrupted
 }
 
 // Serve architecture registry to frontend
@@ -1120,16 +1144,24 @@ app.post('/api/jobs/:name/train/stop', async (req, res) => {
     try {
         const jobName = sanitizeName(req.params.name);
         const job = runningJobs.get(jobName);
+        const queueIndex = trainingQueue.indexOf(jobName);
 
-        if (!job) {
-            return res.status(400).json({ error: 'Job not running' });
+        if (!job && queueIndex === -1) {
+            return res.status(400).json({ error: 'Job not running or queued' });
         }
 
-        runningJobs.delete(jobName);
-        broadcastStatus(jobName, 'stopping');
+        if (job) {
+            runningJobs.delete(jobName);
+            broadcastStatus(jobName, 'stopping');
+            if (job.pid) {
+                killProcess(job.pid, 8000).catch(() => {});
+            }
+        }
 
-        if (job.pid) {
-            killProcess(job.pid, 8000).catch(() => {});
+        if (queueIndex > -1) {
+            trainingQueue.splice(queueIndex, 1);
+            broadcastStatus(jobName, 'dequeued');
+            saveQueue();
         }
 
         res.json({ success: true });
@@ -1454,192 +1486,220 @@ app.post('/api/jobs/:name/train/start', async (req, res) => {
         if (!fs.existsSync(configPath)) {
             return res.status(404).json({ error: 'Job not found' });
         }
-        if (runningJobs.has(jobName)) {
-            return res.status(400).json({ error: 'Job already running' });
+        if (trainingQueue.includes(jobName) || runningJobs.has(jobName)) {
+            return res.status(400).json({ error: 'Job is already running or queued' });
         }
 
-        // Auto-kill persistent gen server to free VRAM
-        if (persistentGenProcess) {
-            console.log("Stopping persistent generation server before training...");
-            killPersistentGen();
-        }
+        trainingQueue.push(jobName);
+        saveQueue();
+        broadcastStatus(jobName, 'queued');
+        processTrainingQueue();
 
-        // Build merged config and write to temp file
-        const mergedConfig = buildTrainingConfig(jobName, jobPath);
-
-        // TP/SP: strip options that are incompatible with the TP training script.
-        const launchMode = mergedConfig.training_arguments?.multigpu_mode
-            || (mergedConfig.training_arguments?.deepspeed ? 'deepspeed' : (mergedConfig.training_arguments?.use_fsdp ? 'fsdp' : 'ddp'));
-        if (launchMode === 'tp_sp' && mergedConfig.training_arguments) {
-            mergedConfig.training_arguments.sequence_parallel = true;
-            // Normalize tp_degree with NaN guard
-            let tp = Number(mergedConfig.training_arguments.tp_degree || 2);
-            if (!Number.isFinite(tp)) tp = 2;
-            mergedConfig.training_arguments.tp_degree = Math.max(2, tp);
-            // Validate tp_backend against whitelist
-            const allowedBackends = ['nccl', 'cuda_direct', 'gloo', 'mpi'];
-            const rawBackend = mergedConfig.training_arguments.tp_backend || (isWindows ? 'gloo' : 'nccl');
-            mergedConfig.training_arguments.tp_backend = allowedBackends.includes(rawBackend) ? rawBackend : (isWindows ? 'gloo' : 'nccl');
-            delete mergedConfig.training_arguments.use_cuda_direct;
-            delete mergedConfig.training_arguments.save_state;
-            delete mergedConfig.training_arguments.save_state_on_train_end;
-            delete mergedConfig.training_arguments.save_last_n_steps_state;
-            delete mergedConfig.training_arguments.save_last_n_epochs_state;
-        } else if (mergedConfig.training_arguments) {
-            delete mergedConfig.training_arguments.no_fuse_qkv;
-            delete mergedConfig.training_arguments.tp_backend;
-            delete mergedConfig.training_arguments.tp_degree;
-            delete mergedConfig.training_arguments.sequence_parallel;
-        }
-
-        if (mergedConfig.training_arguments && launchMode !== 'deepspeed') {
-            delete mergedConfig.training_arguments.deepspeed;
-            delete mergedConfig.training_arguments.zero_stage;
-            delete mergedConfig.training_arguments.offload_optimizer_device;
-            delete mergedConfig.training_arguments.offload_optimizer_nvme_path;
-            delete mergedConfig.training_arguments.offload_param_device;
-            delete mergedConfig.training_arguments.offload_param_nvme_path;
-            delete mergedConfig.training_arguments.zero3_init_flag;
-            delete mergedConfig.training_arguments.zero3_save_16bit_model;
-            delete mergedConfig.training_arguments.fp16_master_weights_and_gradients;
-        } else if (mergedConfig.training_arguments) {
-            mergedConfig.training_arguments.deepspeed = true;
-        }
-
-        // Convert Windows paths to WSL paths when running under WSL
-        if (isWSL) {
-            // Convert all paths in merged config (model paths, output dirs, etc.)
-            const converted = convertPathsInObject(mergedConfig);
-            // Also convert image_dir entries inside dataset.toml -> write a WSL version
-            const datasetPath = path.join(jobPath, 'dataset.toml');
-            if (fs.existsSync(datasetPath)) {
-                const datasetRaw = TOML.parse(fs.readFileSync(datasetPath, 'utf8'));
-                const datasetConverted = convertPathsInObject(datasetRaw);
-                const mergedDatasetPath = path.join(jobPath, '_merged_dataset.toml');
-                fs.writeFileSync(mergedDatasetPath, TOML.stringify(datasetConverted), 'utf8');
-                if (converted.dataset_arguments) {
-                    converted.dataset_arguments.dataset_config = mergedDatasetPath;
-                }
-            }
-            Object.assign(mergedConfig, converted);
-        }
-
-        const mergedConfigPath = path.join(jobPath, '_merged_config.toml');
-        fs.writeFileSync(mergedConfigPath, TOML.stringify(mergedConfig), 'utf8');
-
-        // Ensure output dirs exist
-        const outputDir = path.join(jobPath, 'output');
-        const logsDir = path.join(jobPath, 'logs');
-        if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
-        if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
-
-        // Get venv path from global config
-        const globalConfig = getGlobalConfig();
-        const venvPath = toNativePath(globalConfig.venv_path || path.join(ROOT_DIR, 'venv'));
-        const venv = getVenvPaths(venvPath);
-
-        const jobArch = getArchForJob(mergedConfig);
-        const hasNetwork = !!(mergedConfig.network_arguments && mergedConfig.network_arguments.network_module);
-
-        let currentGpuIds = '';
-        try {
-            const rawConfig = TOML.parse(fs.readFileSync(configPath, 'utf8'));
-            currentGpuIds = rawConfig.gpu_ids ? rawConfig.gpu_ids.toString().trim() : '';
-        } catch (err) {
-            console.warn("Failed to parse config for GPU options:", err);
-        }
-
-        const launch = buildLaunchConfig(currentGpuIds, mergedConfig, mergedConfigPath, jobArch);
-        if (launch.error) return res.status(400).json({ error: launch.error });
-        const { gpuEnv, accelerateFlags, tpTrainCmd } = launch;
-
-        const resolvedMode = mergedConfig.training_arguments?.multigpu_mode
-            || (mergedConfig.training_arguments?.deepspeed ? 'deepspeed' : (mergedConfig.training_arguments?.use_fsdp ? 'fsdp' : 'ddp'));
-
-        let trainCmd;
-        if (resolvedMode === 'tp_sp' && tpTrainCmd) {
-            trainCmd = tpTrainCmd;
-        } else {
-            const scriptName = hasNetwork ? jobArch.scripts.train_network : jobArch.scripts.train;
-            const targetScript = path.join(ROOT_DIR, scriptName);
-            trainCmd = `python -m accelerate.commands.launch --num_cpu_threads_per_process 1 ${accelerateFlags} "${targetScript}" --config_file="${mergedConfigPath}"`;
-        }
-
-        // Spawn training process
-        const isMultiGpu = currentGpuIds && currentGpuIds.split(',').map(s => s.trim()).filter(s => s.length > 0).length > 1;
-        const trainEnvVars = [
-            buildEnvVar('PYTHONIOENCODING', 'utf-8'),
-            buildEnvVar('TOKENIZERS_PARALLELISM', 'false'),
-            gpuEnv,
-            mergedConfig.training_arguments?.step_profile ? buildEnvVar('STEP_PROFILE', '1') : '',
-            mergedConfig.training_arguments?.profile_microbatch ? buildEnvVar('PROFILE_MICROBATCH', '1') : '',
-            (isWindows && isMultiGpu) ? buildEnvVar('USE_LIBUV', '0') : '',
-            (isWindows && isMultiGpu) ? buildEnvVar('MASTER_ADDR', '127.0.0.1') : '',
-            (isWindows && isMultiGpu) ? buildEnvVar('MASTER_PORT', '29500') : ''
-        ].filter(Boolean).join('\n');
-        const trainScript = buildShellScript(venv.activate, trainEnvVars, trainCmd);
-
-        const scriptPath = path.join(jobPath, isWindows ? 'launch_command.ps1' : 'launch_command.sh');
-        fs.writeFileSync(scriptPath, trainScript, 'utf8');
-        console.log(`\n--- Training Launch Command for ${jobName} ---`);
-        console.log(trainScript);
-        console.log("----------------------------------------------\n");
-
-        const proc = spawnShell(trainScript, ROOT_DIR);
-
-        const logBuffer = [];
-        const MAX_LOG_LINES = 5000;
-
-        // Write logs to file
-        const logFileName = `train_${new Date().toISOString().replace(/[:.]/g, '-')}.log`;
-        const logStream = fs.createWriteStream(path.join(logsDir, logFileName), { flags: 'a' });
-
-        const appendLog = (data) => {
-            const text = data.toString();
-            logBuffer.push(text);
-            if (logBuffer.length > MAX_LOG_LINES) logBuffer.shift();
-            logStream.write(text);
-            broadcastLog(jobName, text);
-        };
-
-        proc.stdout.on('data', appendLog);
-        proc.stderr.on('data', appendLog);
-
-        // Prevent crashes on stream errors
-        proc.stdout.on('error', (err) => console.error(`[Train/stdout] ${err.message}`));
-        proc.stderr.on('error', (err) => console.error(`[Train/stderr] ${err.message}`));
-        logStream.on('error', (err) => console.error(`[Train/LogFile] ${err.message}`));
-
-        proc.on('close', (code) => {
-            const msg = `\n--- Training ${code === 0 ? 'completed' : 'stopped'} (exit code: ${code}) ---\n`;
-            logStream.write(msg);
-            logStream.end();
-            appendLog(Buffer.from(msg));
-            runningJobs.delete(jobName);
-            broadcastStatus(jobName, 'idle');
-        });
-
-        proc.on('error', (err) => {
-            appendLog(Buffer.from(`\nERROR: ${err.message}\n`));
-            runningJobs.delete(jobName);
-            broadcastStatus(jobName, 'idle');
-        });
-
-        runningJobs.set(jobName, {
-            process: proc,
-            pid: proc.pid,
-            startTime: Date.now(),
-            logBuffer,
-            type: 'training',
-            gpuIds: currentGpuIds
-        });
-
-        broadcastStatus(jobName, 'running');
-        res.json({ success: true, pid: proc.pid });
+        res.json({ success: true, status: 'queued' });
     } catch (err) {
         res.status(500).json({ error: err.message });
     }
 });
+
+function executeTraining(jobName) {
+    const jobPath = getJobPath(jobName);
+    const configPath = path.join(jobPath, 'config.toml');
+    // Auto-kill persistent gen server to free VRAM
+    if (persistentGenProcess) {
+        console.log("Stopping persistent generation server before training...");
+        killPersistentGen();
+    }
+
+    // Build merged config and write to temp file
+    const mergedConfig = buildTrainingConfig(jobName, jobPath);
+
+    // TP/SP: strip options that are incompatible with the TP training script.
+    const launchMode = mergedConfig.training_arguments?.multigpu_mode
+        || (mergedConfig.training_arguments?.deepspeed ? 'deepspeed' : (mergedConfig.training_arguments?.use_fsdp ? 'fsdp' : 'ddp'));
+    if (launchMode === 'tp_sp' && mergedConfig.training_arguments) {
+        mergedConfig.training_arguments.sequence_parallel = true;
+        // Normalize tp_degree with NaN guard
+        let tp = Number(mergedConfig.training_arguments.tp_degree || 2);
+        if (!Number.isFinite(tp)) tp = 2;
+        mergedConfig.training_arguments.tp_degree = Math.max(2, tp);
+        // Validate tp_backend against whitelist
+        const allowedBackends = ['nccl', 'cuda_direct', 'gloo', 'mpi'];
+        const rawBackend = mergedConfig.training_arguments.tp_backend || (isWindows ? 'gloo' : 'nccl');
+        mergedConfig.training_arguments.tp_backend = allowedBackends.includes(rawBackend) ? rawBackend : (isWindows ? 'gloo' : 'nccl');
+        delete mergedConfig.training_arguments.use_cuda_direct;
+        delete mergedConfig.training_arguments.save_state;
+        delete mergedConfig.training_arguments.save_state_on_train_end;
+        delete mergedConfig.training_arguments.save_last_n_steps_state;
+        delete mergedConfig.training_arguments.save_last_n_epochs_state;
+    } else if (mergedConfig.training_arguments) {
+        delete mergedConfig.training_arguments.no_fuse_qkv;
+        delete mergedConfig.training_arguments.tp_backend;
+        delete mergedConfig.training_arguments.tp_degree;
+        delete mergedConfig.training_arguments.sequence_parallel;
+    }
+
+    if (mergedConfig.training_arguments && launchMode !== 'deepspeed') {
+        delete mergedConfig.training_arguments.deepspeed;
+        delete mergedConfig.training_arguments.zero_stage;
+        delete mergedConfig.training_arguments.offload_optimizer_device;
+        delete mergedConfig.training_arguments.offload_optimizer_nvme_path;
+        delete mergedConfig.training_arguments.offload_param_device;
+        delete mergedConfig.training_arguments.offload_param_nvme_path;
+        delete mergedConfig.training_arguments.zero3_init_flag;
+        delete mergedConfig.training_arguments.zero3_save_16bit_model;
+        delete mergedConfig.training_arguments.fp16_master_weights_and_gradients;
+    } else if (mergedConfig.training_arguments) {
+        mergedConfig.training_arguments.deepspeed = true;
+    }
+
+    // Convert Windows paths to WSL paths when running under WSL
+    if (isWSL) {
+        // Convert all paths in merged config (model paths, output dirs, etc.)
+        const converted = convertPathsInObject(mergedConfig);
+        // Also convert image_dir entries inside dataset.toml -> write a WSL version
+        const datasetPath = path.join(jobPath, 'dataset.toml');
+        if (fs.existsSync(datasetPath)) {
+            const datasetRaw = TOML.parse(fs.readFileSync(datasetPath, 'utf8'));
+            const datasetConverted = convertPathsInObject(datasetRaw);
+            const mergedDatasetPath = path.join(jobPath, '_merged_dataset.toml');
+            fs.writeFileSync(mergedDatasetPath, TOML.stringify(datasetConverted), 'utf8');
+            if (converted.dataset_arguments) {
+                converted.dataset_arguments.dataset_config = mergedDatasetPath;
+            }
+        }
+        Object.assign(mergedConfig, converted);
+    }
+
+    const mergedConfigPath = path.join(jobPath, '_merged_config.toml');
+    fs.writeFileSync(mergedConfigPath, TOML.stringify(mergedConfig), 'utf8');
+
+    // Ensure output dirs exist
+    const outputDir = path.join(jobPath, 'output');
+    const logsDir = path.join(jobPath, 'logs');
+    if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
+    if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
+
+    // Get venv path from global config
+    const globalConfig = getGlobalConfig();
+    const venvPath = toNativePath(globalConfig.venv_path || path.join(ROOT_DIR, 'venv'));
+    const venv = getVenvPaths(venvPath);
+
+    const jobArch = getArchForJob(mergedConfig);
+    const hasNetwork = !!(mergedConfig.network_arguments && mergedConfig.network_arguments.network_module);
+
+    let currentGpuIds = '';
+    try {
+        const rawConfig = TOML.parse(fs.readFileSync(configPath, 'utf8'));
+        currentGpuIds = rawConfig.gpu_ids ? rawConfig.gpu_ids.toString().trim() : '';
+    } catch (err) {
+        console.warn("Failed to parse config for GPU options:", err);
+    }
+
+    const launch = buildLaunchConfig(currentGpuIds, mergedConfig, mergedConfigPath, jobArch);
+    if (launch.error) {
+        console.error(`[Queue Error] Failed to launch job ${jobName}:`, launch.error);
+        broadcastLog(jobName, `\nLAUNCH ERROR: ${launch.error}\n`);
+        broadcastStatus(jobName, 'idle');
+        processTrainingQueue(); // Continue processing other items in the queue
+        return;
+    }
+    const { gpuEnv, accelerateFlags, tpTrainCmd } = launch;
+
+    const resolvedMode = mergedConfig.training_arguments?.multigpu_mode
+        || (mergedConfig.training_arguments?.deepspeed ? 'deepspeed' : (mergedConfig.training_arguments?.use_fsdp ? 'fsdp' : 'ddp'));
+
+    let trainCmd;
+    if (resolvedMode === 'tp_sp' && tpTrainCmd) {
+        trainCmd = tpTrainCmd;
+    } else {
+        const scriptName = hasNetwork ? jobArch.scripts.train_network : jobArch.scripts.train;
+        const targetScript = path.join(ROOT_DIR, scriptName);
+        trainCmd = `python -m accelerate.commands.launch --num_cpu_threads_per_process 1 ${accelerateFlags} "${targetScript}" --config_file="${mergedConfigPath}"`;
+    }
+
+    // Spawn training process
+    const isMultiGpu = currentGpuIds && currentGpuIds.split(',').map(s => s.trim()).filter(s => s.length > 0).length > 1;
+    const trainEnvVars = [
+        buildEnvVar('PYTHONIOENCODING', 'utf-8'),
+        buildEnvVar('TOKENIZERS_PARALLELISM', 'false'),
+        gpuEnv,
+        mergedConfig.training_arguments?.step_profile ? buildEnvVar('STEP_PROFILE', '1') : '',
+        mergedConfig.training_arguments?.profile_microbatch ? buildEnvVar('PROFILE_MICROBATCH', '1') : '',
+        (isWindows && isMultiGpu) ? buildEnvVar('USE_LIBUV', '0') : '',
+        (isWindows && isMultiGpu) ? buildEnvVar('MASTER_ADDR', '127.0.0.1') : '',
+        (isWindows && isMultiGpu) ? buildEnvVar('MASTER_PORT', '29500') : ''
+    ].filter(Boolean).join('\n');
+    const trainScript = buildShellScript(venv.activate, trainEnvVars, trainCmd);
+
+    const scriptPath = path.join(jobPath, isWindows ? 'launch_command.ps1' : 'launch_command.sh');
+    fs.writeFileSync(scriptPath, trainScript, 'utf8');
+    console.log(`\n--- Training Launch Command for ${jobName} ---`);
+    console.log(trainScript);
+    console.log("----------------------------------------------\n");
+
+    const proc = spawnShell(trainScript, ROOT_DIR);
+
+    const logBuffer = [];
+    const MAX_LOG_LINES = 5000;
+
+    // Write logs to file
+    const logFileName = `train_${new Date().toISOString().replace(/[:.]/g, '-')}.log`;
+    const logStream = fs.createWriteStream(path.join(logsDir, logFileName), { flags: 'a' });
+
+    const appendLog = (data) => {
+        const text = data.toString();
+        logBuffer.push(text);
+        if (logBuffer.length > MAX_LOG_LINES) logBuffer.shift();
+        logStream.write(text);
+        broadcastLog(jobName, text);
+    };
+
+    proc.stdout.on('data', appendLog);
+    proc.stderr.on('data', appendLog);
+
+    // Prevent crashes on stream errors
+    proc.stdout.on('error', (err) => console.error(`[Train/stdout] ${err.message}`));
+    proc.stderr.on('error', (err) => console.error(`[Train/stderr] ${err.message}`));
+    logStream.on('error', (err) => console.error(`[Train/LogFile] ${err.message}`));
+
+    proc.on('close', (code) => {
+        const msg = `\n--- Training ${code === 0 ? 'completed' : 'stopped'} (exit code: ${code}) ---\n`;
+        logStream.write(msg);
+        logStream.end();
+        appendLog(Buffer.from(msg));
+        runningJobs.delete(jobName);
+        broadcastStatus(jobName, 'idle');
+        processTrainingQueue();
+    });
+
+    proc.on('error', (err) => {
+        appendLog(Buffer.from(`\nERROR: ${err.message}\n`));
+        runningJobs.delete(jobName);
+        broadcastStatus(jobName, 'idle');
+        processTrainingQueue();
+    });
+
+    runningJobs.set(jobName, {
+        process: proc,
+        pid: proc.pid,
+        startTime: Date.now(),
+        logBuffer,
+        type: 'training',
+        gpuIds: currentGpuIds
+    });
+    broadcastStatus(jobName, 'running');
+}
+
+function processTrainingQueue() {
+    const isTrainingRunning = Array.from(runningJobs.values()).some(job => job.type === 'training');
+    if (isTrainingRunning) return;
+
+    if (trainingQueue.length > 0) {
+        const nextJobName = trainingQueue.shift();
+        saveQueue();
+        executeTraining(nextJobName);
+    }
+}
 
 
 app.get('/api/jobs/:name/train/status', (req, res) => {
@@ -1976,4 +2036,10 @@ async function findAvailablePort(startPort, maxAttempts = 10) {
     });
 })();
 
-
+app.get('/api/train/queue', (req, res) => {
+    try {
+        res.json(trainingQueue);
+    } catch (err) {
+        res.status(500).json({ error: err.message });
+    }
+});

--- a/training-ui/server.js
+++ b/training-ui/server.js
@@ -496,12 +496,17 @@ wss.on('connection', (ws) => {
                 wsClients.get(msg.job).add(ws);
 
                 // Send current status
-                const isRunning = runningJobs.has(msg.job);
-                const isQueued = trainingQueue.includes(msg.job);
+                const jobType = runningJobs.get(msg.job)?.type;
+                const status =
+                    jobType === 'generation' ? 'generating' :
+                    jobType === 'training' ? 'running' :
+                    trainingQueue.includes(msg.job) ? 'queued' :
+                    'idle';
+
                 ws.send(JSON.stringify({
                     job: msg.job,
                     type: 'status',
-                    data: isRunning ? 'running' : (isQueued ? 'queued' : 'idle')
+                    data: status
                 }));
 
                 // Send buffered logs
@@ -716,10 +721,19 @@ app.put('/api/jobs/:name', (req, res) => {
 // Delete job
 app.delete('/api/jobs/:name', (req, res) => {
     try {
-        const jobPath = getJobPath(req.params.name);
-        if (runningJobs.has(req.params.name)) {
+        const jobName = sanitizeName(req.params.name);
+        const jobPath = getJobPath(jobName);
+        if (runningJobs.has(jobName)) {
             return res.status(400).json({ error: 'Stop job before deleting' });
         }
+
+        // Remove from queue if it is waiting
+        const queueIndex = trainingQueue.indexOf(jobName);
+        if (queueIndex > -1) {
+            trainingQueue.splice(queueIndex, 1);
+            saveQueue();
+        }
+
         if (fs.existsSync(jobPath)) {
             fs.rmSync(jobPath, { recursive: true });
         }
@@ -1216,8 +1230,8 @@ app.get('/api/jobs/:name/checkpoints', (req, res) => {
 app.post('/api/jobs/:name/generate', async (req, res) => {
     try {
         const jobName = sanitizeName(req.params.name);
-        if (runningJobs.has(jobName)) {
-            return res.status(400).json({ error: 'Job is running. Stop it first.' });
+        if (runningJobs.has(jobName) || trainingQueue.includes(jobName)) {
+            return res.status(400).json({ error: 'Job is running or queued. Stop it first.' });
         }
 
         const jobPath = getJobPath(jobName);
@@ -1706,8 +1720,8 @@ function processTrainingQueue() {
 app.get('/api/jobs/:name/train/status', (req, res) => {
     try {
         const jobName = sanitizeName(req.params.name);
-        const isRunning = runningJobs.has(jobName);
-        res.json({ running: isRunning });
+        const job = runningJobs.get(jobName);
+        res.json({ running: job ? job.type === 'training' : false });
     } catch (err) {
         res.status(500).json({ error: err.message });
     }

--- a/training-ui/server.js
+++ b/training-ui/server.js
@@ -1519,192 +1519,199 @@ app.post('/api/jobs/:name/train/start', async (req, res) => {
 });
 
 function executeTraining(jobName) {
-    const jobPath = getJobPath(jobName);
-    const configPath = path.join(jobPath, 'config.toml');
-    // Auto-kill persistent gen server to free VRAM
-    if (persistentGenProcess) {
-        console.log("Stopping persistent generation server before training...");
-        killPersistentGen();
-    }
-
-    // Build merged config and write to temp file
-    const mergedConfig = buildTrainingConfig(jobName, jobPath);
-
-    // TP/SP: strip options that are incompatible with the TP training script.
-    const launchMode = mergedConfig.training_arguments?.multigpu_mode
-        || (mergedConfig.training_arguments?.deepspeed ? 'deepspeed' : (mergedConfig.training_arguments?.use_fsdp ? 'fsdp' : 'ddp'));
-    if (launchMode === 'tp_sp' && mergedConfig.training_arguments) {
-        mergedConfig.training_arguments.sequence_parallel = true;
-        // Normalize tp_degree with NaN guard
-        let tp = Number(mergedConfig.training_arguments.tp_degree || 2);
-        if (!Number.isFinite(tp)) tp = 2;
-        mergedConfig.training_arguments.tp_degree = Math.max(2, tp);
-        // Validate tp_backend against whitelist
-        const allowedBackends = ['nccl', 'cuda_direct', 'gloo', 'mpi'];
-        const rawBackend = mergedConfig.training_arguments.tp_backend || (isWindows ? 'gloo' : 'nccl');
-        mergedConfig.training_arguments.tp_backend = allowedBackends.includes(rawBackend) ? rawBackend : (isWindows ? 'gloo' : 'nccl');
-        delete mergedConfig.training_arguments.use_cuda_direct;
-        delete mergedConfig.training_arguments.save_state;
-        delete mergedConfig.training_arguments.save_state_on_train_end;
-        delete mergedConfig.training_arguments.save_last_n_steps_state;
-        delete mergedConfig.training_arguments.save_last_n_epochs_state;
-    } else if (mergedConfig.training_arguments) {
-        delete mergedConfig.training_arguments.no_fuse_qkv;
-        delete mergedConfig.training_arguments.tp_backend;
-        delete mergedConfig.training_arguments.tp_degree;
-        delete mergedConfig.training_arguments.sequence_parallel;
-    }
-
-    if (mergedConfig.training_arguments && launchMode !== 'deepspeed') {
-        delete mergedConfig.training_arguments.deepspeed;
-        delete mergedConfig.training_arguments.zero_stage;
-        delete mergedConfig.training_arguments.offload_optimizer_device;
-        delete mergedConfig.training_arguments.offload_optimizer_nvme_path;
-        delete mergedConfig.training_arguments.offload_param_device;
-        delete mergedConfig.training_arguments.offload_param_nvme_path;
-        delete mergedConfig.training_arguments.zero3_init_flag;
-        delete mergedConfig.training_arguments.zero3_save_16bit_model;
-        delete mergedConfig.training_arguments.fp16_master_weights_and_gradients;
-    } else if (mergedConfig.training_arguments) {
-        mergedConfig.training_arguments.deepspeed = true;
-    }
-
-    // Convert Windows paths to WSL paths when running under WSL
-    if (isWSL) {
-        // Convert all paths in merged config (model paths, output dirs, etc.)
-        const converted = convertPathsInObject(mergedConfig);
-        // Also convert image_dir entries inside dataset.toml -> write a WSL version
-        const datasetPath = path.join(jobPath, 'dataset.toml');
-        if (fs.existsSync(datasetPath)) {
-            const datasetRaw = TOML.parse(fs.readFileSync(datasetPath, 'utf8'));
-            const datasetConverted = convertPathsInObject(datasetRaw);
-            const mergedDatasetPath = path.join(jobPath, '_merged_dataset.toml');
-            fs.writeFileSync(mergedDatasetPath, TOML.stringify(datasetConverted), 'utf8');
-            if (converted.dataset_arguments) {
-                converted.dataset_arguments.dataset_config = mergedDatasetPath;
-            }
-        }
-        Object.assign(mergedConfig, converted);
-    }
-
-    const mergedConfigPath = path.join(jobPath, '_merged_config.toml');
-    fs.writeFileSync(mergedConfigPath, TOML.stringify(mergedConfig), 'utf8');
-
-    // Ensure output dirs exist
-    const outputDir = path.join(jobPath, 'output');
-    const logsDir = path.join(jobPath, 'logs');
-    if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
-    if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
-
-    // Get venv path from global config
-    const globalConfig = getGlobalConfig();
-    const venvPath = toNativePath(globalConfig.venv_path || path.join(ROOT_DIR, 'venv'));
-    const venv = getVenvPaths(venvPath);
-
-    const jobArch = getArchForJob(mergedConfig);
-    const hasNetwork = !!(mergedConfig.network_arguments && mergedConfig.network_arguments.network_module);
-
-    let currentGpuIds = '';
     try {
-        const rawConfig = TOML.parse(fs.readFileSync(configPath, 'utf8'));
-        currentGpuIds = rawConfig.gpu_ids ? rawConfig.gpu_ids.toString().trim() : '';
+        const jobPath = getJobPath(jobName);
+        const configPath = path.join(jobPath, 'config.toml');
+        // Auto-kill persistent gen server to free VRAM
+        if (persistentGenProcess) {
+            console.log("Stopping persistent generation server before training...");
+            killPersistentGen();
+        }
+
+        // Build merged config and write to temp file
+        const mergedConfig = buildTrainingConfig(jobName, jobPath);
+
+        // TP/SP: strip options that are incompatible with the TP training script.
+        const launchMode = mergedConfig.training_arguments?.multigpu_mode
+            || (mergedConfig.training_arguments?.deepspeed ? 'deepspeed' : (mergedConfig.training_arguments?.use_fsdp ? 'fsdp' : 'ddp'));
+        if (launchMode === 'tp_sp' && mergedConfig.training_arguments) {
+            mergedConfig.training_arguments.sequence_parallel = true;
+            // Normalize tp_degree with NaN guard
+            let tp = Number(mergedConfig.training_arguments.tp_degree || 2);
+            if (!Number.isFinite(tp)) tp = 2;
+            mergedConfig.training_arguments.tp_degree = Math.max(2, tp);
+            // Validate tp_backend against whitelist
+            const allowedBackends = ['nccl', 'cuda_direct', 'gloo', 'mpi'];
+            const rawBackend = mergedConfig.training_arguments.tp_backend || (isWindows ? 'gloo' : 'nccl');
+            mergedConfig.training_arguments.tp_backend = allowedBackends.includes(rawBackend) ? rawBackend : (isWindows ? 'gloo' : 'nccl');
+            delete mergedConfig.training_arguments.use_cuda_direct;
+            delete mergedConfig.training_arguments.save_state;
+            delete mergedConfig.training_arguments.save_state_on_train_end;
+            delete mergedConfig.training_arguments.save_last_n_steps_state;
+            delete mergedConfig.training_arguments.save_last_n_epochs_state;
+        } else if (mergedConfig.training_arguments) {
+            delete mergedConfig.training_arguments.no_fuse_qkv;
+            delete mergedConfig.training_arguments.tp_backend;
+            delete mergedConfig.training_arguments.tp_degree;
+            delete mergedConfig.training_arguments.sequence_parallel;
+        }
+
+        if (mergedConfig.training_arguments && launchMode !== 'deepspeed') {
+            delete mergedConfig.training_arguments.deepspeed;
+            delete mergedConfig.training_arguments.zero_stage;
+            delete mergedConfig.training_arguments.offload_optimizer_device;
+            delete mergedConfig.training_arguments.offload_optimizer_nvme_path;
+            delete mergedConfig.training_arguments.offload_param_device;
+            delete mergedConfig.training_arguments.offload_param_nvme_path;
+            delete mergedConfig.training_arguments.zero3_init_flag;
+            delete mergedConfig.training_arguments.zero3_save_16bit_model;
+            delete mergedConfig.training_arguments.fp16_master_weights_and_gradients;
+        } else if (mergedConfig.training_arguments) {
+            mergedConfig.training_arguments.deepspeed = true;
+        }
+
+        // Convert Windows paths to WSL paths when running under WSL
+        if (isWSL) {
+            // Convert all paths in merged config (model paths, output dirs, etc.)
+            const converted = convertPathsInObject(mergedConfig);
+            // Also convert image_dir entries inside dataset.toml -> write a WSL version
+            const datasetPath = path.join(jobPath, 'dataset.toml');
+            if (fs.existsSync(datasetPath)) {
+                const datasetRaw = TOML.parse(fs.readFileSync(datasetPath, 'utf8'));
+                const datasetConverted = convertPathsInObject(datasetRaw);
+                const mergedDatasetPath = path.join(jobPath, '_merged_dataset.toml');
+                fs.writeFileSync(mergedDatasetPath, TOML.stringify(datasetConverted), 'utf8');
+                if (converted.dataset_arguments) {
+                    converted.dataset_arguments.dataset_config = mergedDatasetPath;
+                }
+            }
+            Object.assign(mergedConfig, converted);
+        }
+
+        const mergedConfigPath = path.join(jobPath, '_merged_config.toml');
+        fs.writeFileSync(mergedConfigPath, TOML.stringify(mergedConfig), 'utf8');
+
+        // Ensure output dirs exist
+        const outputDir = path.join(jobPath, 'output');
+        const logsDir = path.join(jobPath, 'logs');
+        if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
+        if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
+
+        // Get venv path from global config
+        const globalConfig = getGlobalConfig();
+        const venvPath = toNativePath(globalConfig.venv_path || path.join(ROOT_DIR, 'venv'));
+        const venv = getVenvPaths(venvPath);
+
+        const jobArch = getArchForJob(mergedConfig);
+        const hasNetwork = !!(mergedConfig.network_arguments && mergedConfig.network_arguments.network_module);
+
+        let currentGpuIds = '';
+        try {
+            const rawConfig = TOML.parse(fs.readFileSync(configPath, 'utf8'));
+            currentGpuIds = rawConfig.gpu_ids ? rawConfig.gpu_ids.toString().trim() : '';
+        } catch (err) {
+            console.warn("Failed to parse config for GPU options:", err);
+        }
+
+        const launch = buildLaunchConfig(currentGpuIds, mergedConfig, mergedConfigPath, jobArch);
+        if (launch.error) {
+            console.error(`[Queue Error] Failed to launch job ${jobName}:`, launch.error);
+            broadcastLog(jobName, `\nLAUNCH ERROR: ${launch.error}\n`);
+            broadcastStatus(jobName, 'idle');
+            processTrainingQueue(); // Continue processing other items in the queue
+            return;
+        }
+        const { gpuEnv, accelerateFlags, tpTrainCmd } = launch;
+
+        const resolvedMode = mergedConfig.training_arguments?.multigpu_mode
+            || (mergedConfig.training_arguments?.deepspeed ? 'deepspeed' : (mergedConfig.training_arguments?.use_fsdp ? 'fsdp' : 'ddp'));
+
+        let trainCmd;
+        if (resolvedMode === 'tp_sp' && tpTrainCmd) {
+            trainCmd = tpTrainCmd;
+        } else {
+            const scriptName = hasNetwork ? jobArch.scripts.train_network : jobArch.scripts.train;
+            const targetScript = path.join(ROOT_DIR, scriptName);
+            trainCmd = `python -m accelerate.commands.launch --num_cpu_threads_per_process 1 ${accelerateFlags} "${targetScript}" --config_file="${mergedConfigPath}"`;
+        }
+
+        // Spawn training process
+        const isMultiGpu = currentGpuIds && currentGpuIds.split(',').map(s => s.trim()).filter(s => s.length > 0).length > 1;
+        const trainEnvVars = [
+            buildEnvVar('PYTHONIOENCODING', 'utf-8'),
+            buildEnvVar('TOKENIZERS_PARALLELISM', 'false'),
+            gpuEnv,
+            mergedConfig.training_arguments?.step_profile ? buildEnvVar('STEP_PROFILE', '1') : '',
+            mergedConfig.training_arguments?.profile_microbatch ? buildEnvVar('PROFILE_MICROBATCH', '1') : '',
+            (isWindows && isMultiGpu) ? buildEnvVar('USE_LIBUV', '0') : '',
+            (isWindows && isMultiGpu) ? buildEnvVar('MASTER_ADDR', '127.0.0.1') : '',
+            (isWindows && isMultiGpu) ? buildEnvVar('MASTER_PORT', '29500') : ''
+        ].filter(Boolean).join('\n');
+        const trainScript = buildShellScript(venv.activate, trainEnvVars, trainCmd);
+
+        const scriptPath = path.join(jobPath, isWindows ? 'launch_command.ps1' : 'launch_command.sh');
+        fs.writeFileSync(scriptPath, trainScript, 'utf8');
+        console.log(`\n--- Training Launch Command for ${jobName} ---`);
+        console.log(trainScript);
+        console.log("----------------------------------------------\n");
+
+        const proc = spawnShell(trainScript, ROOT_DIR);
+
+        const logBuffer = [];
+        const MAX_LOG_LINES = 5000;
+
+        // Write logs to file
+        const logFileName = `train_${new Date().toISOString().replace(/[:.]/g, '-')}.log`;
+        const logStream = fs.createWriteStream(path.join(logsDir, logFileName), { flags: 'a' });
+
+        const appendLog = (data) => {
+            const text = data.toString();
+            logBuffer.push(text);
+            if (logBuffer.length > MAX_LOG_LINES) logBuffer.shift();
+            logStream.write(text);
+            broadcastLog(jobName, text);
+        };
+
+        proc.stdout.on('data', appendLog);
+        proc.stderr.on('data', appendLog);
+
+        // Prevent crashes on stream errors
+        proc.stdout.on('error', (err) => console.error(`[Train/stdout] ${err.message}`));
+        proc.stderr.on('error', (err) => console.error(`[Train/stderr] ${err.message}`));
+        logStream.on('error', (err) => console.error(`[Train/LogFile] ${err.message}`));
+
+        proc.on('close', (code) => {
+            const msg = `\n--- Training ${code === 0 ? 'completed' : 'stopped'} (exit code: ${code}) ---\n`;
+            logStream.write(msg);
+            logStream.end();
+            appendLog(Buffer.from(msg));
+            runningJobs.delete(jobName);
+            broadcastStatus(jobName, 'idle');
+            processTrainingQueue();
+        });
+
+        proc.on('error', (err) => {
+            appendLog(Buffer.from(`\nERROR: ${err.message}\n`));
+            runningJobs.delete(jobName);
+            broadcastStatus(jobName, 'idle');
+            processTrainingQueue();
+        });
+
+        runningJobs.set(jobName, {
+            process: proc,
+            pid: proc.pid,
+            startTime: Date.now(),
+            logBuffer,
+            type: 'training',
+            gpuIds: currentGpuIds
+        });
+        broadcastStatus(jobName, 'running');
     } catch (err) {
-        console.warn("Failed to parse config for GPU options:", err);
-    }
-
-    const launch = buildLaunchConfig(currentGpuIds, mergedConfig, mergedConfigPath, jobArch);
-    if (launch.error) {
-        console.error(`[Queue Error] Failed to launch job ${jobName}:`, launch.error);
-        broadcastLog(jobName, `\nLAUNCH ERROR: ${launch.error}\n`);
-        broadcastStatus(jobName, 'idle');
-        processTrainingQueue(); // Continue processing other items in the queue
-        return;
-    }
-    const { gpuEnv, accelerateFlags, tpTrainCmd } = launch;
-
-    const resolvedMode = mergedConfig.training_arguments?.multigpu_mode
-        || (mergedConfig.training_arguments?.deepspeed ? 'deepspeed' : (mergedConfig.training_arguments?.use_fsdp ? 'fsdp' : 'ddp'));
-
-    let trainCmd;
-    if (resolvedMode === 'tp_sp' && tpTrainCmd) {
-        trainCmd = tpTrainCmd;
-    } else {
-        const scriptName = hasNetwork ? jobArch.scripts.train_network : jobArch.scripts.train;
-        const targetScript = path.join(ROOT_DIR, scriptName);
-        trainCmd = `python -m accelerate.commands.launch --num_cpu_threads_per_process 1 ${accelerateFlags} "${targetScript}" --config_file="${mergedConfigPath}"`;
-    }
-
-    // Spawn training process
-    const isMultiGpu = currentGpuIds && currentGpuIds.split(',').map(s => s.trim()).filter(s => s.length > 0).length > 1;
-    const trainEnvVars = [
-        buildEnvVar('PYTHONIOENCODING', 'utf-8'),
-        buildEnvVar('TOKENIZERS_PARALLELISM', 'false'),
-        gpuEnv,
-        mergedConfig.training_arguments?.step_profile ? buildEnvVar('STEP_PROFILE', '1') : '',
-        mergedConfig.training_arguments?.profile_microbatch ? buildEnvVar('PROFILE_MICROBATCH', '1') : '',
-        (isWindows && isMultiGpu) ? buildEnvVar('USE_LIBUV', '0') : '',
-        (isWindows && isMultiGpu) ? buildEnvVar('MASTER_ADDR', '127.0.0.1') : '',
-        (isWindows && isMultiGpu) ? buildEnvVar('MASTER_PORT', '29500') : ''
-    ].filter(Boolean).join('\n');
-    const trainScript = buildShellScript(venv.activate, trainEnvVars, trainCmd);
-
-    const scriptPath = path.join(jobPath, isWindows ? 'launch_command.ps1' : 'launch_command.sh');
-    fs.writeFileSync(scriptPath, trainScript, 'utf8');
-    console.log(`\n--- Training Launch Command for ${jobName} ---`);
-    console.log(trainScript);
-    console.log("----------------------------------------------\n");
-
-    const proc = spawnShell(trainScript, ROOT_DIR);
-
-    const logBuffer = [];
-    const MAX_LOG_LINES = 5000;
-
-    // Write logs to file
-    const logFileName = `train_${new Date().toISOString().replace(/[:.]/g, '-')}.log`;
-    const logStream = fs.createWriteStream(path.join(logsDir, logFileName), { flags: 'a' });
-
-    const appendLog = (data) => {
-        const text = data.toString();
-        logBuffer.push(text);
-        if (logBuffer.length > MAX_LOG_LINES) logBuffer.shift();
-        logStream.write(text);
-        broadcastLog(jobName, text);
-    };
-
-    proc.stdout.on('data', appendLog);
-    proc.stderr.on('data', appendLog);
-
-    // Prevent crashes on stream errors
-    proc.stdout.on('error', (err) => console.error(`[Train/stdout] ${err.message}`));
-    proc.stderr.on('error', (err) => console.error(`[Train/stderr] ${err.message}`));
-    logStream.on('error', (err) => console.error(`[Train/LogFile] ${err.message}`));
-
-    proc.on('close', (code) => {
-        const msg = `\n--- Training ${code === 0 ? 'completed' : 'stopped'} (exit code: ${code}) ---\n`;
-        logStream.write(msg);
-        logStream.end();
-        appendLog(Buffer.from(msg));
-        runningJobs.delete(jobName);
+        console.error(`[Queue Error] executeTraining failed for ${jobName}:`, err);
+        broadcastLog(jobName, `\nEXECUTION ERROR: ${err.message}\n`);
         broadcastStatus(jobName, 'idle');
         processTrainingQueue();
-    });
-
-    proc.on('error', (err) => {
-        appendLog(Buffer.from(`\nERROR: ${err.message}\n`));
-        runningJobs.delete(jobName);
-        broadcastStatus(jobName, 'idle');
-        processTrainingQueue();
-    });
-
-    runningJobs.set(jobName, {
-        process: proc,
-        pid: proc.pid,
-        startTime: Date.now(),
-        logBuffer,
-        type: 'training',
-        gpuIds: currentGpuIds
-    });
-    broadcastStatus(jobName, 'running');
+    }
 }
 
 function processTrainingQueue() {


### PR DESCRIPTION
This PR introduces a persistent, sequential job queue system, allowing users to line up multiple training sessions that will execute automatically one after the other.
### High-Level Overview
* **Job Queuing:** Users can now click "Train" on multiple jobs. The first job starts immediately, and subsequent jobs are placed in a queue. As soon as a job finishes or crashes, the next job in the queue starts automatically.
* **Queue Persistence:** The queue state is saved to disk (`queue.json`), meaning pending jobs survive server crashes or restarts.
* **New UI Panel:** A collapsible queue panel has been added to the sidebar to monitor the waitlist and allow users to cancel pending jobs globally.

---

### Backend Changes (`server.js`)
* **Queue State Machine:** Extracted the core shell-spawning logic from the `/train/start` endpoint into a standalone `executeTraining()` worker function.
* **Worker Loop:** Added `processTrainingQueue()`, which checks if the GPU is free and shifts the next job off the `trainingQueue` array. This is hooked into the `close` and `error` events of the training process to chain executions.
* **Persistence Layer:** Added `loadQueue()` and `saveQueue()` to write the queue to `queue.json` synchronously on any mutation.
* **Endpoint Protection & Edge Cases:**
  * `POST /train/start`: Pushes to the queue and triggers the processor instead of immediate execution.
  * `POST /train/stop`: Now handles both killing active PIDs and safely splicing jobs out of the array if they are only queued.
  * `DELETE /api/jobs/:name`: Now splices the job out of the queue before wiping the directory to prevent worker crashes.
  * `POST /generate`: Added safety checks to prevent generation scripts from running if a job is sitting in the queue.
  * `GET /api/jobs`: Now returns a `queued: true/false` boolean in the payload for frontend rendering.
* **Global WebSockets:** Modified `broadcastStatus` to send state changes to *all* connected clients simultaneously, keeping the sidebar accurate regardless of which job is active in the editor.

---

### Frontend Changes (`app.js`, `index.html`, `style.css`)
* **Queue Visibility Panel:** Added a collapsible `⏳ Queue` UI in the bottom left sidebar with a dynamic numerical badge. It lists pending jobs in order and includes a quick-action `✕` button to dequeue them.
* **Dynamic Status Handling (`updateJobStatus`):** * Replaced the binary `updateRunningState` with a robust multi-state machine (`idle`, `queued`, `running`).
  * The main execution button now dynamically transforms from a green **▶ Train** button to an amber **⏹ Cancel Queue** button, and finally to a red **⏹ Stop Training** button.
* **Sidebar Indicators:** Added a new amber `.queued` state with a custom pulse animation for the sidebar status dots.
* **WebSocket Fixes:** * Removed the `msg.job !== currentJob` block to allow global status updates to reach the sidebar/queue UI.
  * Sequestered `consoleOutput` so it only renders logs if the message explicitly matches the open `currentJob`.
* **Form Philosophy:** Form inputs intentionally remain unlocked while jobs are queued, allo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs can be queued for training; a Queue API and processing ensure queued jobs run when possible.
  * Queue panel in the sidebar shows queued jobs, allows removal with confirmation, and persists queue state.

* **UI Improvements**
  * Distinct queued/running badge styles and pulse animation; updated Train button theme and queue panel toggle.
  * Console/toast behavior improved to reflect queued vs immediate starts.

* **Bug Fixes**
  * Stop now handles both running and queued jobs appropriately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gazingstars123/Anima-Standalone-Trainer/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->