### PR TITLE
Add timestep bias strategy configuration for training

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -6216,6 +6216,11 @@ def get_timesteps(
     if strategy is None:
         raise ValueError(f"Unknown timestep bias strategy: {timestep_bias_strategy}")
 
+    if min_timestep >= max_timestep:
+        raise ValueError(
+            f"min_timestep must be less than max_timestep, got {min_timestep} >= {max_timestep}"
+        )
+
     if min_timestep < max_timestep:
         max_index = max_timestep - 1
         if strategy == "none":
@@ -6229,8 +6234,6 @@ def get_timesteps(
 
             timestep_span = max(max_index - min_timestep, 0)
             timesteps = (biased_timesteps * timestep_span + min_timestep).long().clamp(min_timestep, max_index)
-    else:
-        timesteps = torch.full((b_size,), max_timestep, device="cpu")
     timesteps = timesteps.long().to(device)
     return timesteps
 

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4156,6 +4156,13 @@ def add_training_arguments(parser: argparse.ArgumentParser, support_dreambooth: 
         help="set maximum time step for U-Net training (1~1000, default is 1000) / U-Net学習時のtime stepの最大値を設定する（1~1000で指定、省略時はデフォルト値(1000)）",
     )
     parser.add_argument(
+        "--timestep_bias_strategy",
+        type=str,
+        default="none",
+        choices=["none", "earlier", "later", "balanced", "content", "style"],
+        help="bias timestep sampling with ai-toolkit's cubic strategy: `earlier`/`content` favors lower timesteps, `later`/`style` favors higher timesteps, and `none`/`balanced` keeps uniform sampling / ai-toolkit互換の三次サンプリングでtime stepを偏らせる。`earlier`/`content`は小さいtime step寄り、`later`/`style`は大きいtime step寄り、`none`/`balanced`は一様サンプリング",
+    )
+    parser.add_argument(
         "--loss_type",
         type=str,
         default="l2",
@@ -6190,9 +6197,38 @@ def save_sd_model_on_train_end_common(
             huggingface_util.upload(args, out_dir, "/" + model_name, force_sync_upload=True)
 
 
-def get_timesteps(min_timestep: int, max_timestep: int, b_size: int, device: torch.device) -> torch.Tensor:
+def get_timesteps(
+    min_timestep: int,
+    max_timestep: int,
+    b_size: int,
+    device: torch.device,
+    timestep_bias_strategy: str = "none",
+) -> torch.Tensor:
+    strategy_aliases = {
+        "balanced": "none",
+        "content": "earlier",
+        "earlier": "earlier",
+        "later": "later",
+        "none": "none",
+        "style": "later",
+    }
+    strategy = strategy_aliases.get(timestep_bias_strategy.lower())
+    if strategy is None:
+        raise ValueError(f"Unknown timestep bias strategy: {timestep_bias_strategy}")
+
     if min_timestep < max_timestep:
-        timesteps = torch.randint(min_timestep, max_timestep, (b_size,), device="cpu")
+        max_index = max_timestep - 1
+        if strategy == "none":
+            timesteps = torch.randint(min_timestep, max_timestep, (b_size,), device="cpu")
+        else:
+            orig_timesteps = torch.rand((b_size,), device="cpu")
+            if strategy == "earlier":
+                biased_timesteps = orig_timesteps**3
+            else:
+                biased_timesteps = 1 - orig_timesteps**3
+
+            timestep_span = max(max_index - min_timestep, 0)
+            timesteps = (biased_timesteps * timestep_span + min_timestep).long().clamp(min_timestep, max_index)
     else:
         timesteps = torch.full((b_size,), max_timestep, device="cpu")
     timesteps = timesteps.long().to(device)
@@ -6219,7 +6255,8 @@ def get_noise_noisy_latents_and_timesteps(
     b_size = latents.shape[0]
     min_timestep = 0 if args.min_timestep is None else args.min_timestep
     max_timestep = noise_scheduler.config.num_train_timesteps if args.max_timestep is None else args.max_timestep
-    timesteps = get_timesteps(min_timestep, max_timestep, b_size, latents.device)
+    timestep_bias_strategy = getattr(args, "timestep_bias_strategy", "none")
+    timesteps = get_timesteps(min_timestep, max_timestep, b_size, latents.device, timestep_bias_strategy)
 
     # Add noise to the latents according to the noise magnitude at each timestep
     # (this is the forward diffusion process)

--- a/training-ui/public/index.html
+++ b/training-ui/public/index.html
@@ -314,6 +314,14 @@
                                 </select>
                             </div>
                             <div class="form-group">
+                                <label>Timestep Bias</label>
+                                <select id="cfg-timestep-bias-strategy">
+                                    <option value="none">None</option>
+                                    <option value="earlier">Earlier (Content)</option>
+                                    <option value="later">Later (Style)</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
                                 <label>Flow Shift</label>
                                 <input type="number" id="cfg-flow-shift" value="3.0" step="0.1" min="0">
                             </div>

--- a/training-ui/public/js/app.js
+++ b/training-ui/public/js/app.js
@@ -404,6 +404,7 @@ function populateConfig(config) {
   $("cfg-vae-batch").value = t.vae_batch_size ?? 1;
   $("cfg-cache-te").checked = t.cache_text_encoder_outputs_to_disk ?? true;
   $("cfg-disable-bucket-shuffle").checked = t.disable_bucket_shuffle ?? false;
+  $("cfg-timestep-bias-strategy").value = t.timestep_bias_strategy || "none";
   // Progressive resolution schedule
   if (t.resolution_schedule) {
     $("cfg-progressive-reso").checked = true;
@@ -777,6 +778,7 @@ function gatherConfig() {
       // Diagnostics
       step_profile: $("cfg-step-profile").checked,
       profile_microbatch: $("cfg-profile-microbatch").checked,
+      timestep_bias_strategy: $("cfg-timestep-bias-strategy").value,
       // Progressive resolution schedule
       ...(() => {
         if (!$("cfg-progressive-reso").checked) return {};

--- a/training-ui/public/js/app.js
+++ b/training-ui/public/js/app.js
@@ -404,7 +404,9 @@ function populateConfig(config) {
   $("cfg-vae-batch").value = t.vae_batch_size ?? 1;
   $("cfg-cache-te").checked = t.cache_text_encoder_outputs_to_disk ?? true;
   $("cfg-disable-bucket-shuffle").checked = t.disable_bucket_shuffle ?? false;
-  $("cfg-timestep-bias-strategy").value = t.timestep_bias_strategy || "none";
+  $("cfg-timestep-bias-strategy").value = normalizeTimestepBiasStrategy(
+    t.timestep_bias_strategy,
+  );
   // Progressive resolution schedule
   if (t.resolution_schedule) {
     $("cfg-progressive-reso").checked = true;
@@ -619,6 +621,22 @@ function safeFloat(val, fallback = 0.0) {
   const p = parseFloat(val);
   return isNaN(p) ? fallback : p;
 }
+
+function normalizeTimestepBiasStrategy(value) {
+  switch ((value || "none").toLowerCase()) {
+    case "content":
+    case "earlier":
+      return "earlier";
+    case "style":
+    case "later":
+      return "later";
+    case "balanced":
+    case "none":
+    default:
+      return "none";
+  }
+}
+
 function gatherConfig() {
   const unit = document.querySelector(
     'input[name="duration-unit"]:checked',
@@ -778,7 +796,9 @@ function gatherConfig() {
       // Diagnostics
       step_profile: $("cfg-step-profile").checked,
       profile_microbatch: $("cfg-profile-microbatch").checked,
-      timestep_bias_strategy: $("cfg-timestep-bias-strategy").value,
+      timestep_bias_strategy: normalizeTimestepBiasStrategy(
+        $("cfg-timestep-bias-strategy").value,
+      ),
       // Progressive resolution schedule
       ...(() => {
         if (!$("cfg-progressive-reso").checked) return {};

--- a/training-ui/templates/config_template.toml
+++ b/training-ui/templates/config_template.toml
@@ -23,6 +23,7 @@ persistent_data_loader_workers = true
 seed = 42
 cache_latents_to_disk = true
 cache_text_encoder_outputs_to_disk = true
+timestep_bias_strategy = "none"
 sample_every_n_epochs = 1
 
 [network_arguments]


### PR DESCRIPTION
Add timestep bias strategy configuration for training
Like in ai-tookit by ostris. 
Could be beneficial training only for style or content - only training on lower or higher steps.
Japanese translation was done by ai, so I don't know if it's good or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Timestep Bias strategy for training (options: none, earlier, later, balanced, content, style). Default is "none".
  * Exposed in the Training UI (new dropdown in the Training tab) and available as a command-line/config option; influences how training timesteps are sampled.
* **Documentation**
  * Configuration template updated to include the new setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gazingstars123/Anima-Standalone-Trainer/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->