### PR TITLE
fix(ui): block launch when autosave fails

### DIFF
--- a/training-ui/public/js/app.js
+++ b/training-ui/public/js/app.js
@@ -1049,7 +1049,7 @@ function renderSubsets() {
 //  Save
 // ==========================================
 async function saveJob() {
-  if (!currentJob) return;
+  if (!currentJob) return false;
   const config = gatherConfig();
   const dataset = gatherDataset();
   // Prevent duplicate directories
@@ -1061,15 +1061,20 @@ async function saveJob() {
     showToast(
       "Error: Duplicate Image Directories detected. Each subset must have a unique path.",
     );
-    return;
+    return false;
   }
-  // Save Config & Dataset
-  await api(`/api/jobs/${currentJob}`, {
-    method: "PUT",
-    body: { config, dataset },
-  });
-  // Save Prompts
-  await savePrompts();
+  try {
+    // Save Config & Dataset
+    await api(`/api/jobs/${currentJob}`, {
+      method: "PUT",
+      body: { config, dataset },
+    });
+    // Save Prompts
+    await savePrompts();
+  } catch (err) {
+    showToast("Error saving job: " + err.message);
+    return false;
+  }
   // Update last saved state
   lastSavedConfig = JSON.parse(JSON.stringify(config));
   lastSavedDataset = JSON.parse(JSON.stringify(dataset));
@@ -1077,6 +1082,7 @@ async function saveJob() {
   lastSavedNegativePrompt = $("global-negative-prompt").value;
   checkDirty();
   showToast("Job saved");
+  return true;
 }
 function checkDirty() {
   if (!currentJob) return;
@@ -3085,7 +3091,7 @@ $("btn-run").addEventListener("click", async () => {
       "Sampling is enabled but no prompts are defined.\n\nContinue training without generating samples...\n\n";
   }
   // Auto-save first
-  if (isDirty) await saveJob();
+  if (isDirty && !(await saveJob())) return;
   const result = await api(`/api/jobs/${currentJob}/train/start`, {
     method: "POST",
   });
@@ -3104,7 +3110,7 @@ $("btn-run").addEventListener("click", async () => {
 $("btn-gen-sample").addEventListener("click", async () => {
   if (!currentJob) return;
   savePromptTransientSettings();
-  if (isDirty) await saveJob();
+  if (isDirty && !(await saveJob())) return;
   if (currentPrompts.length === 0) {
     showToast("Add sample prompts first");
     return;


### PR DESCRIPTION
  ## Problem
  When the UI has unsaved changes and the user clicks Train or Generate, the frontend attempts to auto-save the current job first. If that save fails, for example because duplicate Dataset image directories are configured, the UI shows an error but still proceeds to start training or generation.

  This behavior is illogical. If the job fails to save successfully, the process should be blocked rather than allowed to start. This could mislead users into believing their latest form modifications have taken effect, whereas the system is actually executing the previously saved, outdated configuration, potentially resulting in a waste of training time and GPU resources.

  ## Root Cause
  `saveJob()` returned early on validation failure without reporting failure to its callers.

https://github.com/gazingstars123/Anima-Standalone-Trainer/blob/8cc2c08ad8e8ba8e3b9a8c99ab64872dc200a4ae/training-ui/public/js/app.js#L1060-L1065

   And the Train/Generate handlers only did `await saveJob()`and did not check whether the save succeeded, so they continued to call the launch APIs even after autosave failed.

https://github.com/gazingstars123/Anima-Standalone-Trainer/blob/8cc2c08ad8e8ba8e3b9a8c99ab64872dc200a4ae/training-ui/public/js/app.js#L3087-L3088

https://github.com/gazingstars123/Anima-Standalone-Trainer/blob/8cc2c08ad8e8ba8e3b9a8c99ab64872dc200a4ae/training-ui/public/js/app.js#L3103-L3107

  ## Fix
  `saveJob()` now returns an explicit boolean:
  - `true` when the job is saved successfully
  - `false` when validation fails or the save API throws