### PR TITLE
Support checkpoints with model.diffusion_model. prefix

### DIFF
--- a/library/anima_utils.py
+++ b/library/anima_utils.py
@@ -57,12 +57,20 @@ def load_anima_dit(
     else:
         state_dict = load_file(dit_path, device="cpu")
 
-    # Remove 'net.' prefix if present
+    # Normalize checkpoint prefixes
+    prefixes = (
+        "net.",
+        "model.diffusion_model.",
+    )
+
     new_state_dict = {}
     for k, v in state_dict.items():
-        if k.startswith('net.'):
-            k = k[len('net.'):]
+        for prefix in prefixes:
+            if k.startswith(prefix):
+                k = k[len(prefix):]
+                break
         new_state_dict[k] = v
+
     state_dict = new_state_dict
 
     # Derive config from state_dict


### PR DESCRIPTION
Some Anima-based checkpoints are saved with the `model.diffusion_model.` prefix instead of `net.`.
This PR strips both prefixes during loading, improving checkpoint compatibility.

Fixes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint loading to recognize multiple key prefix formats, helping more models load correctly without manual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->